### PR TITLE
serverErrors renamed to externalErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,5 +102,5 @@
 
 ### v0.2.1
 
-- Reworked how server errors are updated. Fixes a bug where an exception would be thrown if the tree shapes didn't match. This could happen if you have a field which creates an object or array, which are not translated to leaf nodes internally.
+- Reworked how external errors are updated. Fixes a bug where an exception would be thrown if the tree shapes didn't match. This could happen if you have a field which creates an object or array, which are not translated to leaf nodes internally.
 - Added CHANGELOG

--- a/README.md
+++ b/README.md
@@ -386,12 +386,12 @@ export default function CustomChange() {
 
 ### External validation
 
-Oftentimes, you will want to show errors from an external source (such as the server) in your form alongside any client-side validation errors. These can be passed into your `<Form>` component using the `serverErrors` (TODO(zach): change to `externalErrors`?) prop.
+Oftentimes, you will want to show errors from an external source (such as the server) in your form alongside any client-side validation errors. These can be passed into your `<Form>` component using the `externalErrors` prop.
 
 These errors must be in an object with keys representing the path to the field they should be associated with. For example, the errors:
 
 ```js
-const serverErrors = {
+const externalErrors = {
   "/": "User failed to save!",
   "/email": "A user with this email already exists!",
 };
@@ -400,7 +400,7 @@ const serverErrors = {
 could be used in this form:
 
 ```jsx
-<Form serverErrors={serverErrors}>
+<Form externalErrors={externalErrors}>
   {(link, handleSubmit) => (
     <>
       <ObjectField link={link}>

--- a/src/ErrorsHelper.js
+++ b/src/ErrorsHelper.js
@@ -1,7 +1,7 @@
 // @flow strict
 
 import * as React from "react";
-import type {FieldLink, ClientErrors, ServerErrors, Err} from "./types";
+import type {FieldLink, ClientErrors, ExternalErrors, Err} from "./types";
 import {FormContext} from "./Form";
 import {getExtras} from "./formState";
 
@@ -10,8 +10,8 @@ function flattenErrors(errors: Err) {
   if (errors.client !== "pending") {
     flatErrors = flatErrors.concat(errors.client);
   }
-  if (errors.server !== "unchecked") {
-    flatErrors = flatErrors.concat(errors.server);
+  if (errors.external !== "unchecked") {
+    flatErrors = flatErrors.concat(errors.external);
   }
   return flatErrors;
 }
@@ -21,7 +21,7 @@ type Props<T> = {|
   +children: ({
     shouldShowErrors: boolean,
     client: ClientErrors,
-    server: ServerErrors,
+    external: ExternalErrors,
     flattened: Array<string>,
   }) => React.Node,
 |};
@@ -33,7 +33,7 @@ export default function ErrorsHelper<T>(props: Props<T>) {
   return props.children({
     shouldShowErrors,
     client: errors.client,
-    server: errors.server,
+    external: errors.external,
     flattened,
   });
 }

--- a/src/Field.js
+++ b/src/Field.js
@@ -23,8 +23,8 @@ function getErrors(errors: Err) {
   if (errors.client !== "pending") {
     flatErrors = flatErrors.concat(errors.client);
   }
-  if (errors.server !== "unchecked") {
-    flatErrors = flatErrors.concat(errors.server);
+  if (errors.external !== "unchecked") {
+    flatErrors = flatErrors.concat(errors.external);
   }
   return flatErrors;
 }
@@ -72,7 +72,7 @@ export default class Field<T> extends React.Component<Props<T>> {
     const [_, tree] = this.props.link.formState;
 
     this.props.link.onBlur(
-      // TODO(zach): Not sure if we should blow away server errors here
+      // TODO(zach): Not sure if we should blow away external errors here
       mapRoot(setExtrasTouched, tree)
     );
   };

--- a/src/formState.js
+++ b/src/formState.js
@@ -54,8 +54,8 @@ export function flatRootErrors<T>(formState: FormState<T>): Array<string> {
   if (errors.client !== "pending") {
     flatErrors = flatErrors.concat(errors.client);
   }
-  if (errors.server !== "unchecked") {
-    flatErrors = flatErrors.concat(errors.server);
+  if (errors.external !== "unchecked") {
+    flatErrors = flatErrors.concat(errors.external);
   }
   return flatErrors;
 }

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -79,7 +79,7 @@ describe("ArrayField", () => {
       const formState = mockFormState(["value"]);
       // $FlowFixMe
       formState[1].data.errors = {
-        server: ["A server error"],
+        external: ["An external error"],
         client: ["A client error"],
       };
       const link = mockLink(formState);
@@ -96,7 +96,7 @@ describe("ArrayField", () => {
           changed: false,
           shouldShowErrors: expect.anything(),
           unfilteredErrors: expect.arrayContaining([
-            "A server error",
+            "An external error",
             "A client error",
           ]),
           valid: false,

--- a/src/test/Field.test.js
+++ b/src/test/Field.test.js
@@ -133,7 +133,7 @@ describe("Field", () => {
         ...oldRoot,
         errors: {
           client: ["Some", "client", "errors"],
-          server: ["Server errors", "go here"],
+          external: ["External errors", "go here"],
         },
       }),
       formState[1]
@@ -147,7 +147,7 @@ describe("Field", () => {
       "Some",
       "client",
       "errors",
-      "Server errors",
+      "External errors",
       "go here",
     ]);
   });
@@ -187,7 +187,7 @@ describe("Field", () => {
     const formState = mockFormState(10);
     // $FlowFixMe
     formState[1].data.errors = {
-      server: ["A server error"],
+      external: ["An external error"],
       client: ["A client error"],
     };
     const link = mockLink(formState);
@@ -206,7 +206,7 @@ describe("Field", () => {
         changed: false,
         shouldShowErrors: expect.anything(),
         unfilteredErrors: expect.arrayContaining([
-          "A server error",
+          "An external error",
           "A client error",
         ]),
         valid: false,

--- a/src/test/Form.test.js
+++ b/src/test/Form.test.js
@@ -290,14 +290,14 @@ describe("Form", () => {
   });
 
   describe("Form manages form state", () => {
-    it("creates the initial formState from initialValue and serverErrors", () => {
+    it("creates the initial formState from initialValue and externalErrors", () => {
       const onSubmit = jest.fn();
       const renderFn = jest.fn(() => null);
       TestRenderer.create(
         <Form
           initialValue={1}
           onSubmit={onSubmit}
-          serverErrors={{"/": ["Server error", "Another server error"]}}
+          externalErrors={{"/": ["External error", "Another external error"]}}
         >
           {renderFn}
         </Form>
@@ -320,12 +320,12 @@ describe("Form", () => {
         },
         errors: {
           client: "pending",
-          server: ["Server error", "Another server error"],
+          external: ["External error", "Another external error"],
         },
       });
     });
 
-    it("parses and sets complex server errors", () => {
+    it("parses and sets complex external errors", () => {
       const onSubmit = jest.fn();
       const renderFn = jest.fn(() => null);
       TestRenderer.create(
@@ -335,7 +335,7 @@ describe("Form", () => {
             complex: [{inner: "hello"}, {inner: "there"}],
           }}
           onSubmit={onSubmit}
-          serverErrors={{
+          externalErrors={{
             "/": ["Root error"],
             "/simple": ["One", "level", "down"],
             "/complex": [],
@@ -354,18 +354,18 @@ describe("Form", () => {
       const [_, tree] = link.formState;
       // Cross your fingers
       const root: any = tree;
-      expect(root.data.errors.server).toEqual(["Root error"]);
+      expect(root.data.errors.external).toEqual(["Root error"]);
       const simple = root.children.simple;
-      expect(simple.data.errors.server).toEqual(["One", "level", "down"]);
+      expect(simple.data.errors.external).toEqual(["One", "level", "down"]);
       const complex = root.children.complex;
-      expect(complex.data.errors.server).toEqual([]);
+      expect(complex.data.errors.external).toEqual([]);
       const complex0 = complex.children[0];
-      expect(complex0.data.errors.server).toEqual(["in an", "array"]);
+      expect(complex0.data.errors.external).toEqual(["in an", "array"]);
       const complex1 = complex.children[1];
-      expect(complex1.data.errors.server).toEqual([]);
+      expect(complex1.data.errors.external).toEqual([]);
     });
 
-    it("updates the server errors", () => {
+    it("updates the external errors", () => {
       const onSubmit = jest.fn();
       const renderFn = jest.fn(() => null);
       const renderer = TestRenderer.create(
@@ -374,7 +374,7 @@ describe("Form", () => {
             array: [],
           }}
           onSubmit={onSubmit}
-          serverErrors={{
+          externalErrors={{
             "/array": ["Cannot be empty"],
           }}
         >
@@ -395,7 +395,7 @@ describe("Form", () => {
             array: [],
           }}
           onSubmit={onSubmit}
-          serverErrors={{
+          externalErrors={{
             "/array": [],
             "/array/0": ["inner error"],
           }}
@@ -411,11 +411,11 @@ describe("Form", () => {
       const [_, tree] = link.formState;
       // Cross your fingers
       const root: any = tree;
-      expect(root.data.errors.server).toEqual([]);
+      expect(root.data.errors.external).toEqual([]);
       const array = root.children.array;
-      expect(array.data.errors.server).toEqual([]);
+      expect(array.data.errors.external).toEqual([]);
       const array0 = array.children[0];
-      expect(array0.data.errors.server).toEqual(["inner error"]);
+      expect(array0.data.errors.external).toEqual(["inner error"]);
     });
 
     it("doesn't cause an infinite loop when using inline validation function", () => {
@@ -660,7 +660,7 @@ describe("Form", () => {
           initialValue={1}
           feedbackStrategy={FeedbackStrategies.Touched}
           onSubmit={jest.fn()}
-          serverErrors={{"/": ["Server error", "Another server error"]}}
+          externalErrors={{"/": ["External error", "Another external error"]}}
         >
           {renderFn}
         </Form>
@@ -674,8 +674,8 @@ describe("Form", () => {
           changed: false,
           shouldShowErrors: false,
           unfilteredErrors: expect.arrayContaining([
-            "Server error",
-            "Another server error",
+            "External error",
+            "Another external error",
           ]),
           // Currently, only care about client errors
           valid: true,

--- a/src/test/ObjectField.test.js
+++ b/src/test/ObjectField.test.js
@@ -100,7 +100,7 @@ describe("ObjectField", () => {
       const formState = mockFormState({inner: "value"});
       // $FlowFixMe
       formState[1].data.errors = {
-        server: ["A server error"],
+        external: ["An external error"],
         client: ["A client error"],
       };
       const link = mockLink(formState);
@@ -116,7 +116,7 @@ describe("ObjectField", () => {
           changed: false,
           shouldShowErrors: expect.anything(),
           unfilteredErrors: expect.arrayContaining([
-            "A server error",
+            "An external error",
             "A client error",
           ]),
           valid: false,

--- a/src/types.js
+++ b/src/types.js
@@ -5,10 +5,10 @@ import type {Path} from "./tree";
 import {type FormState} from "./formState";
 
 export type ClientErrors = Array<string> | "pending";
-export type ServerErrors = Array<string> | "unchecked";
+export type ExternalErrors = Array<string> | "unchecked";
 export type Err = {
   client: ClientErrors,
-  server: ServerErrors,
+  external: ExternalErrors,
 };
 
 export type MetaField = {
@@ -32,7 +32,7 @@ export const cleanMeta: MetaField = {
 
 export const cleanErrors: Err = {
   client: "pending",
-  server: "unchecked",
+  external: "unchecked",
 };
 
 export type Extras = {


### PR DESCRIPTION
https://github.com/flexport/formula-one/issues/5

This PR renames all instances of serverErrors to externalErrors, and introduces name changes accordingly. This change is non-backwards compatible.