### PR TITLE
Don't remount after customChange

### DIFF
--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -107,7 +107,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
 
   componentDidUpdate(prevProps: Props<E>) {
     if (prevProps.validation !== this.props.validation) {
-      this.validationFnOps.replace(prevProps.validation, this.props.validation);
+      this.validationFnOps.replace(this.props.validation);
     }
   }
 

--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -27,7 +27,7 @@ import {
   zip,
   unzip,
 } from "./utils/array";
-import {FormContext, type ValidationOps, validationFnNoops} from "./Form";
+import {FormContext, type ValidationOps, validationFnNoOps} from "./Form";
 import {
   type FormState,
   replaceArrayChild,
@@ -93,7 +93,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
   };
   static contextType = FormContext;
 
-  validationFnOps: ValidationOps<Array<E>> = validationFnNoops();
+  validationFnOps: ValidationOps<Array<E>> = validationFnNoOps();
 
   componentDidMount() {
     this.validationFnOps = this.context.registerValidation(
@@ -110,7 +110,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
 
   componentWillUnmount() {
     this.validationFnOps.unregister();
-    this.validationFnOps = validationFnNoops();
+    this.validationFnOps = validationFnNoOps();
   }
 
   _handleChildChange: (number, FormState<E>) => void = (

--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -6,14 +6,12 @@ import type {
   FieldLink,
   Validation,
   Extras,
-  ClientErrors,
   AdditionalRenderInfo,
   CustomChange,
 } from "./types";
 import {cleanErrors, cleanMeta} from "./types";
 import {
   type ShapedTree,
-  type ShapedPath,
   treeFromValue,
   dangerouslyReplaceArrayChild,
   mapRoot,
@@ -75,8 +73,7 @@ function makeLinks<E>(
   path: Path,
   formState: FormState<Array<E>>,
   onChildChange: (number, FormState<E>) => void,
-  onChildBlur: (number, ShapedTree<E, Extras>) => void,
-  onChildValidation: (number, ShapedPath<E>, ClientErrors) => void
+  onChildBlur: (number, ShapedTree<E, Extras>) => void
 ): Links<E> {
   const [oldValue] = formState;
   return oldValue.map((x, i) => {
@@ -87,9 +84,6 @@ function makeLinks<E>(
       },
       onBlur: childTree => {
         onChildBlur(i, childTree);
-      },
-      onValidation: (childPath, clientErrors) => {
-        onChildValidation(i, childPath, clientErrors);
       },
       path: [...path, {type: "array", index: i}],
     };
@@ -172,21 +166,6 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
         dangerouslyReplaceArrayChild(index, childTree, tree)
       )
     );
-  };
-
-  _handleChildValidation: (number, ShapedPath<E>, ClientErrors) => void = (
-    index,
-    childPath,
-    errors
-  ) => {
-    const extendedPath = [
-      {
-        type: "array",
-        index,
-      },
-      ...childPath,
-    ];
-    this.props.link.onValidation(extendedPath, errors);
   };
 
   _addChildField: (number, E) => void = (index: number, childValue: E) => {
@@ -339,8 +318,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
       path,
       formState,
       this._handleChildChange,
-      this._handleChildBlur,
-      this._handleChildValidation
+      this._handleChildBlur
     );
     return (
       <React.Fragment>

--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -31,11 +31,8 @@ import {FormContext, type ValidationOps, validationFnNoops} from "./Form";
 import {
   type FormState,
   replaceArrayChild,
-  setTouched,
-  setChanged,
   setExtrasTouched,
   arrayChild,
-  setValidationResult,
   getExtras,
   flatRootErrors,
   isValid,
@@ -140,17 +137,15 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
 
       // A custom change occurred, which means the whole array needs to be
       // revalidated.
-      validatedFormState = this.context.validateFormStateAtPath(
+      validatedFormState = this.context.applyValidationToTreeAtPath(
         this.props.link.path,
         nextFormState
       );
     } else {
-      const errors = this.context.validateAtPath(
+      validatedFormState = this.context.applyValidationAtPath(
         this.props.link.path,
-        newValue
+        newFormState
       );
-      const nextFormState = setChanged(newFormState);
-      validatedFormState = setValidationResult(errors, nextFormState);
     }
     this.props.link.onChange(validatedFormState);
   };
@@ -166,6 +161,14 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
         dangerouslyReplaceArrayChild(index, childTree, tree)
       )
     );
+  };
+
+  _validateThenApplyChange = <E>(formState: FormState<Array<E>>) => {
+    const validatedFormState = this.context.applyValidationAtPath(
+      this.props.link.path,
+      formState
+    );
+    this.props.link.onChange(validatedFormState);
   };
 
   _addChildField: (number, E) => void = (index: number, childValue: E) => {
@@ -184,11 +187,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
       ),
       oldTree
     );
-
-    const errors = this.context.validateAtPath(this.props.link.path, newValue);
-    this.props.link.onChange(
-      setValidationResult(errors, setChanged(setTouched([newValue, newTree])))
-    );
+    this._validateThenApplyChange([newValue, newTree]);
   };
 
   _addChildFields: (
@@ -212,10 +211,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
       oldTree
     );
 
-    const errors = this.context.validateAtPath(this.props.link.path, newValue);
-    this.props.link.onChange(
-      setValidationResult(errors, setChanged(setTouched([newValue, newTree])))
-    );
+    this._validateThenApplyChange([newValue, newTree]);
   };
 
   _filterChildFields: (
@@ -231,10 +227,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     );
     const newTree = dangerouslySetChildren(newChildren, oldTree);
 
-    const errors = this.context.validateAtPath(this.props.link.path, newValue);
-    this.props.link.onChange(
-      setValidationResult(errors, setChanged(setTouched([newValue, newTree])))
-    );
+    this._validateThenApplyChange([newValue, newTree]);
   };
 
   _modifyChildFields: ({
@@ -275,10 +268,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     );
     const newTree = dangerouslySetChildren(newChildren, oldTree);
 
-    const errors = this.context.validateAtPath(this.props.link.path, newValue);
-    this.props.link.onChange(
-      setValidationResult(errors, setChanged(setTouched([newValue, newTree])))
-    );
+    this._validateThenApplyChange([newValue, newTree]);
   };
 
   _removeChildField = (index: number) => {
@@ -290,10 +280,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
       oldTree
     );
 
-    const errors = this.context.validateAtPath(this.props.link.path, newValue);
-    this.props.link.onChange(
-      setValidationResult(errors, setChanged(setTouched([newValue, newTree])))
-    );
+    this._validateThenApplyChange([newValue, newTree]);
   };
 
   _moveChildField = (from: number, to: number) => {
@@ -304,10 +291,8 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
       moveFromTo(from, to, shapedArrayChildren(oldTree)),
       oldTree
     );
-    const errors = this.context.validateAtPath(this.props.link.path, newValue);
-    this.props.link.onChange(
-      setValidationResult(errors, setChanged(setTouched([newValue, newTree])))
-    );
+
+    this._validateThenApplyChange([newValue, newTree]);
   };
 
   render() {

--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -29,7 +29,7 @@ import {
   zip,
   unzip,
 } from "./utils/array";
-import {FormContext} from "./Form";
+import {FormContext, type ValidationOps, validationFnNoops} from "./Form";
 import {
   type FormState,
   replaceArrayChild,
@@ -37,7 +37,7 @@ import {
   setChanged,
   setExtrasTouched,
   arrayChild,
-  validate,
+  setValidationResult,
   getExtras,
   flatRootErrors,
   isValid,
@@ -102,32 +102,24 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
   };
   static contextType = FormContext;
 
-  unregisterValidation = () => {};
-
-  _initialValidate() {
-    const {
-      link: {formState, onValidation},
-      validation,
-    } = this.props;
-    const [value] = formState;
-    const {errors} = getExtras(formState);
-
-    if (errors.client === "pending") {
-      onValidation([], validation(value));
-    }
-  }
+  validationFnOps: ValidationOps<Array<E>> = validationFnNoops();
 
   componentDidMount() {
-    this.unregisterValidation = this.context.registerValidation(
+    this.validationFnOps = this.context.registerValidation(
       this.props.link.path,
       this.props.validation
     );
+  }
 
-    this._initialValidate();
+  componentDidUpdate(prevProps: Props<E>) {
+    if (prevProps.validation !== this.props.validation) {
+      this.validationFnOps.replace(prevProps.validation, this.props.validation);
+    }
   }
 
   componentWillUnmount() {
-    this.unregisterValidation();
+    this.validationFnOps.unregister();
+    this.validationFnOps = validationFnNoops();
   }
 
   _handleChildChange: (number, FormState<E>) => void = (
@@ -158,8 +150,12 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
         nextFormState
       );
     } else {
+      const errors = this.context.validateAtPath(
+        this.props.link.path,
+        newValue
+      );
       const nextFormState = setChanged(newFormState);
-      validatedFormState = validate(this.props.validation, nextFormState);
+      validatedFormState = setValidationResult(errors, nextFormState);
     }
     this.props.link.onChange(validatedFormState);
   };
@@ -209,11 +205,9 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
       oldTree
     );
 
+    const errors = this.context.validateAtPath(this.props.link.path, newValue);
     this.props.link.onChange(
-      validate(
-        this.props.validation,
-        setChanged(setTouched([newValue, newTree]))
-      )
+      setValidationResult(errors, setChanged(setTouched([newValue, newTree])))
     );
   };
 
@@ -238,11 +232,9 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
       oldTree
     );
 
+    const errors = this.context.validateAtPath(this.props.link.path, newValue);
     this.props.link.onChange(
-      validate(
-        this.props.validation,
-        setChanged(setTouched([newValue, newTree]))
-      )
+      setValidationResult(errors, setChanged(setTouched([newValue, newTree])))
     );
   };
 
@@ -259,11 +251,9 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     );
     const newTree = dangerouslySetChildren(newChildren, oldTree);
 
+    const errors = this.context.validateAtPath(this.props.link.path, newValue);
     this.props.link.onChange(
-      validate(
-        this.props.validation,
-        setChanged(setTouched([newValue, newTree]))
-      )
+      setValidationResult(errors, setChanged(setTouched([newValue, newTree])))
     );
   };
 
@@ -305,11 +295,9 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     );
     const newTree = dangerouslySetChildren(newChildren, oldTree);
 
+    const errors = this.context.validateAtPath(this.props.link.path, newValue);
     this.props.link.onChange(
-      validate(
-        this.props.validation,
-        setChanged(setTouched([newValue, newTree]))
-      )
+      setValidationResult(errors, setChanged(setTouched([newValue, newTree])))
     );
   };
 
@@ -322,11 +310,9 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
       oldTree
     );
 
+    const errors = this.context.validateAtPath(this.props.link.path, newValue);
     this.props.link.onChange(
-      validate(
-        this.props.validation,
-        setChanged(setTouched([newValue, newTree]))
-      )
+      setValidationResult(errors, setChanged(setTouched([newValue, newTree])))
     );
   };
 
@@ -338,11 +324,9 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
       moveFromTo(from, to, shapedArrayChildren(oldTree)),
       oldTree
     );
+    const errors = this.context.validateAtPath(this.props.link.path, newValue);
     this.props.link.onChange(
-      validate(
-        this.props.validation,
-        setChanged(setTouched([newValue, newTree]))
-      )
+      setValidationResult(errors, setChanged(setTouched([newValue, newTree])))
     );
   };
 

--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -144,7 +144,8 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
       // TODO(zach): It's kind of gross that this is happening outside of Form.
       const nextFormState = changedFormState(customValue);
 
-      // Sibling nodes changed, so validate the entire subtree.
+      // A custom change occurred, which means the whole array needs to be
+      // revalidated.
       validatedFormState = this.context.validateFormStateAtPath(
         this.props.link.path,
         nextFormState

--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -36,7 +36,6 @@ import {
   getExtras,
   flatRootErrors,
   isValid,
-  changedFormState,
 } from "./formState";
 import type {Path} from "./tree";
 
@@ -125,24 +124,19 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
 
     const oldValue = this.props.link.formState[0];
     const newValue = newFormState[0];
-
     const customValue =
       this.props.customChange && this.props.customChange(oldValue, newValue);
 
     let validatedFormState: FormState<Array<E>>;
     if (customValue) {
-      // Create a fresh form state for the new value.
-      // TODO(zach): It's kind of gross that this is happening outside of Form.
-      const nextFormState = changedFormState(customValue);
-
       // A custom change occurred, which means the whole array needs to be
       // revalidated.
-      validatedFormState = this.context.applyValidationToTreeAtPath(
-        this.props.link.path,
-        nextFormState
-      );
+      validatedFormState = this.context.updateTreeAtPath(this.props.link.path, [
+        customValue,
+        newFormState[1],
+      ]);
     } else {
-      validatedFormState = this.context.applyValidationAtPath(
+      validatedFormState = this.context.updateNodeAtPath(
         this.props.link.path,
         newFormState
       );
@@ -164,7 +158,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
   };
 
   _validateThenApplyChange = <E>(formState: FormState<Array<E>>) => {
-    const validatedFormState = this.context.applyValidationAtPath(
+    const validatedFormState = this.context.updateNodeAtPath(
       this.props.link.path,
       formState
     );

--- a/src/EncodedPath.js
+++ b/src/EncodedPath.js
@@ -1,0 +1,51 @@
+/**
+ * A path suitable for use as a key in a Map.
+ *
+ * Right now just serialized to string, but this is hidden from users of this
+ * module with an opaque type.
+ *
+ * @flow strict
+ */
+
+import {type Path} from "./tree";
+
+opaque type EncodedPath = string;
+export type {EncodedPath};
+
+export function startsWith(path: EncodedPath, prefix: Path) {
+  return path.startsWith(encodePath(prefix));
+}
+
+export function encodePath(path: Path): EncodedPath {
+  return (
+    "/" +
+    path
+      .map(p => {
+        if (p.type === "object") {
+          return `o>${p.key}`;
+        } else if (p.type === "array") {
+          return `a>${p.index}`;
+        } else {
+          (p.type: empty); // eslint-disable-line no-unused-expressions
+          throw new Error(`Bad path type ${p.type}`);
+        }
+      })
+      .join("/")
+  );
+}
+
+export function decodePath(s: EncodedPath): Path {
+  return s
+    .split("/")
+    .filter(x => x !== "")
+    .map(s => {
+      const [type, val] = s.split(">");
+      if (type === "o") {
+        return {type: "object", key: val};
+      } else if (type === "a") {
+        return {type: "array", index: parseInt(val, 10)};
+      } else {
+        throw new Error(`Bad encoded path type '${type}' for path '${s}'`);
+      }
+    });
+}

--- a/src/Field.js
+++ b/src/Field.js
@@ -41,7 +41,9 @@ export default class Field<T> extends React.Component<Props<T>> {
   };
   static contextType = FormContext;
 
-  initialValidate() {
+  unregisterValidation = () => {};
+
+  _initialValidate() {
     const {
       link: {formState, onValidation},
       validation,
@@ -55,7 +57,16 @@ export default class Field<T> extends React.Component<Props<T>> {
   }
 
   componentDidMount() {
-    this.initialValidate();
+    this.unregisterValidation = this.context.registerValidation(
+      this.props.link.path,
+      this.props.validation
+    );
+
+    this._initialValidate();
+  }
+
+  componentWillUnmount() {
+    this.unregisterValidation();
   }
 
   onChange: T => void = (newValue: T) => {

--- a/src/Field.js
+++ b/src/Field.js
@@ -3,7 +3,7 @@
 import * as React from "react";
 import type {FieldLink, Validation, Err, AdditionalRenderInfo} from "./types";
 import {mapRoot} from "./shapedTree";
-import {FormContext, type ValidationOps, validationFnNoops} from "./Form";
+import {FormContext, type ValidationOps, validationFnNoOps} from "./Form";
 import {setExtrasTouched, getExtras, isValid} from "./formState";
 
 type Props<T> = {|
@@ -35,7 +35,7 @@ export default class Field<T> extends React.Component<Props<T>> {
   };
   static contextType = FormContext;
 
-  validationFnOps: ValidationOps<T> = validationFnNoops();
+  validationFnOps: ValidationOps<T> = validationFnNoOps();
 
   componentDidMount() {
     this.validationFnOps = this.context.registerValidation(
@@ -52,7 +52,7 @@ export default class Field<T> extends React.Component<Props<T>> {
 
   componentWillUnmount() {
     this.validationFnOps.unregister();
-    this.validationFnOps = validationFnNoops();
+    this.validationFnOps = validationFnNoOps();
   }
 
   onChange: T => void = (newValue: T) => {

--- a/src/Field.js
+++ b/src/Field.js
@@ -52,7 +52,7 @@ export default class Field<T> extends React.Component<Props<T>> {
 
   componentDidUpdate(prevProps: Props<T>) {
     if (prevProps.validation !== this.props.validation) {
-      this.validationFnOps.replace(prevProps.validation, this.props.validation);
+      this.validationFnOps.replace(this.props.validation);
     }
   }
 

--- a/src/Field.js
+++ b/src/Field.js
@@ -4,13 +4,7 @@ import * as React from "react";
 import type {FieldLink, Validation, Err, AdditionalRenderInfo} from "./types";
 import {mapRoot} from "./shapedTree";
 import {FormContext, type ValidationOps, validationFnNoops} from "./Form";
-import {
-  setExtrasTouched,
-  getExtras,
-  setChanged,
-  setValidationResult,
-  isValid,
-} from "./formState";
+import {setExtrasTouched, getExtras, isValid} from "./formState";
 
 type Props<T> = {|
   +link: FieldLink<T>,
@@ -62,12 +56,16 @@ export default class Field<T> extends React.Component<Props<T>> {
   }
 
   onChange: T => void = (newValue: T) => {
-    const [_, oldTree] = this.props.link.formState;
-    const errors = this.context.validateAtPath(this.props.link.path, newValue);
-
-    this.props.link.onChange(
-      setChanged(setValidationResult(errors, [newValue, oldTree]))
-    );
+    const {
+      path,
+      formState: [_, oldTree],
+      onChange,
+    } = this.props.link;
+    const newFormState = this.context.applyValidationAtPath(path, [
+      newValue,
+      oldTree,
+    ]);
+    onChange(newFormState);
   };
 
   onBlur = () => {

--- a/src/Field.js
+++ b/src/Field.js
@@ -61,7 +61,7 @@ export default class Field<T> extends React.Component<Props<T>> {
       formState: [_, oldTree],
       onChange,
     } = this.props.link;
-    const newFormState = this.context.applyValidationAtPath(path, [
+    const newFormState = this.context.updateNodeAtPath(path, [
       newValue,
       oldTree,
     ]);

--- a/src/Form.js
+++ b/src/Form.js
@@ -39,7 +39,7 @@ export type ValidationOps<T> = {
   replace: (fn: (T) => Array<string>) => void,
 };
 
-export function validationFnNoops<T>(): ValidationOps<T> {
+export function validationFnNoOps<T>(): ValidationOps<T> {
   return {
     unregister() {},
     replace() {},

--- a/src/Form.js
+++ b/src/Form.js
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import invariant from "./utils/invariant";
+import {equals as arrayEquals} from "./utils/array";
 
 import type {
   MetaField,
@@ -131,6 +132,7 @@ function encodePath(path: Path): EncodedPath {
         } else if (p.type === "array") {
           return `a>${p.index}`;
         } else {
+          (p.type: empty); // eslint-disable-line no-unused-expressions
           throw new Error(`Bad path type ${p.type}`);
         }
       })
@@ -236,21 +238,6 @@ function validateAtPath(
     (errors, validationFn) => errors.concat(validationFn(value)),
     []
   );
-}
-
-function arrayEqual(
-  a: $ReadOnlyArray<mixed>,
-  b: $ReadOnlyArray<mixed>
-): boolean {
-  if (a.length !== b.length) {
-    return false;
-  }
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) {
-      return false;
-    }
-  }
-  return true;
 }
 
 type Props<T, ExtraSubmitData> = {|
@@ -444,7 +431,7 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
     // Now that the old validation is gone, make sure there are no left over
     // errors from it.
     const value = getValueAtPath(path, this.state.formState[0]);
-    if (arrayEqual(oldFn(value), newFn(value))) {
+    if (arrayEquals(oldFn(value), newFn(value))) {
       // The errors haven't changed, so don't bother calling setState.
       // You might think this is a silly performance optimization but actually
       // we need this for annoying React reasons:

--- a/src/Form.js
+++ b/src/Form.js
@@ -60,6 +60,8 @@ export type FormContextPayload = {|
     path: Path,
     fn: (mixed) => Array<string>
   ) => ValidationOps<mixed>,
+  // TODO(dmnd): Try to get rid of * here by writing a type-level function of
+  // Path and FormState<T>
   applyValidationToTreeAtPath: (Path, FormState<*>) => FormState<*>,
   applyValidationAtPath: (Path, FormState<*>) => FormState<*>,
 |};

--- a/src/Form.js
+++ b/src/Form.js
@@ -129,10 +129,16 @@ function applyServerErrorsToFormState<T>(
   return [value, tree];
 }
 
-function getValueAtPath(
-  path: Path,
-  value: mixed | number | string | null | void
-) {
+type Value =
+  | mixed
+  | number
+  | string
+  | null
+  | void
+  | Array<Value>
+  | {[string]: Value};
+
+function getValueAtPath(path: Path, value: Value) {
   if (path.length === 0) {
     return value;
   }
@@ -145,7 +151,7 @@ function getValueAtPath(
     return getValueAtPath(rest, value[p.index]);
   } else if (p.type === "object") {
     invariant(
-      typeof value === "object" && value !== null,
+      typeof value === "object" && value !== null && !Array.isArray(value),
       "Path/value shape mismatch: expected object"
     );
     return getValueAtPath(rest, value[p.key]);

--- a/src/Form.js
+++ b/src/Form.js
@@ -7,10 +7,8 @@ import {equals as arrayEquals} from "./utils/array";
 import type {
   MetaField,
   OnBlur,
-  OnValidation,
   Extras,
   FieldLink,
-  ClientErrors,
   AdditionalRenderInfo,
 } from "./types";
 import {
@@ -22,7 +20,6 @@ import {
 } from "./formState";
 import {
   type ShapedTree,
-  type ShapedPath,
   shapePath,
   updateAtPath,
   mapShapedTree,
@@ -353,28 +350,6 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
     });
   };
 
-  _handleValidation: OnValidation<T> = (
-    path: ShapedPath<T>,
-    errors: ClientErrors
-  ) => {
-    // TODO(zach): Move this into formState.js, it is gross
-    const updater = newErrors => ({errors, meta}) => ({
-      errors: {...errors, client: newErrors},
-      meta: {
-        ...meta,
-        succeeded: newErrors.length === 0 ? true : meta.succeeded,
-      },
-    });
-    this.setState(
-      ({formState: [value, tree]}) => ({
-        formState: [value, updateAtPath(path, updater(errors), tree)],
-      }),
-      () => {
-        this.props.onValidation(isValid(this.state.formState));
-      }
-    );
-  };
-
   /**
    * Keeps validation errors from becoming stale when validation functions of
    * children change.
@@ -484,7 +459,6 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
             formState,
             onChange: this._handleChange,
             onBlur: this._handleBlur,
-            onValidation: this._handleValidation,
             path: [],
           },
           this._handleSubmit,

--- a/src/Form.js
+++ b/src/Form.js
@@ -39,11 +39,15 @@ export type ValidationOps<T> = {
   replace: (fn: (T) => Array<string>) => void,
 };
 
+const noOps = {
+  unregister() {},
+  replace() {},
+};
+
+// noOps can't be used directly because Flow doesn't typecheck a constant as
+// being parametric in T.
 export function validationFnNoOps<T>(): ValidationOps<T> {
-  return {
-    unregister() {},
-    replace() {},
-  };
+  return noOps;
 }
 
 export type FormContextPayload = {|

--- a/src/Form.js
+++ b/src/Form.js
@@ -357,14 +357,14 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
    * children change.
    */
   recomputeErrorsAtPathAndRender = (path: Path) => {
-    this.setState(({formState: [value, meta]}) => {
+    this.setState(({formState: [value, tree]}) => {
       const errors = validateAtPath(path, value, this.validations);
-      const updatedMeta = updateAtPath(
+      const updatedTree = updateAtPath(
         path,
         extras => ({...extras, errors: {...extras.errors, client: errors}}),
-        meta
+        tree
       );
-      return {formState: [value, updatedMeta]};
+      return {formState: [value, updatedTree]};
     });
   };
 

--- a/src/Form.js
+++ b/src/Form.js
@@ -24,6 +24,7 @@ import {
   updateAtPath,
   mapShapedTree,
   mapRoot,
+  pathExistsInTree,
 } from "./shapedTree";
 import {pathFromPathString, type Path} from "./tree";
 import {
@@ -451,6 +452,12 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
     const map = this.validations.get(encodedPath);
     invariant(map != null, "Couldn't find handler map during unregister");
     map.delete(fieldId);
+
+    // If the entire path was deleted from the tree, any left over errors are
+    // already gone. For example, this happens when an array child is removed.
+    if (!pathExistsInTree(path, this.state.formState[1])) {
+      return;
+    }
 
     // now that the validation is gone, make sure there are no left over
     // errors from it

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -6,7 +6,6 @@ import type {
   FieldLink,
   Validation,
   Extras,
-  ClientErrors,
   AdditionalRenderInfo,
   CustomChange,
 } from "./types";
@@ -25,7 +24,6 @@ import {
 } from "./formState";
 import {
   type ShapedTree,
-  type ShapedPath,
   mapRoot,
   dangerouslyReplaceObjectChild,
 } from "./shapedTree";
@@ -48,8 +46,7 @@ function makeLinks<T: {}, V>(
   path: Path,
   formState: FormState<T>,
   onChildChange: (string, FormState<V>) => void,
-  onChildBlur: (string, ShapedTree<V, Extras>) => void,
-  onChildValidation: (string, ShapedPath<V>, ClientErrors) => void
+  onChildBlur: (string, ShapedTree<V, Extras>) => void
 ): Links<T> {
   const [value] = formState;
   return Object.keys(value).reduce((memo, k) => {
@@ -60,9 +57,6 @@ function makeLinks<T: {}, V>(
       },
       onBlur: childTree => {
         onChildBlur(k, childTree);
-      },
-      onValidation: (path, errors) => {
-        onChildValidation(k, path, errors);
       },
       path: [...path, {type: "object", key: k}],
     };
@@ -156,23 +150,6 @@ export default class ObjectField<T: {}> extends React.Component<
     );
   };
 
-  _handleChildValidation: <V>(string, ShapedPath<V>, ClientErrors) => void = <
-    V
-  >(
-    key: string,
-    childPath: ShapedPath<V>,
-    errors: ClientErrors
-  ) => {
-    const extendedPath = [
-      {
-        type: "object",
-        key,
-      },
-      ...childPath,
-    ];
-    this.props.link.onValidation(extendedPath, errors);
-  };
-
   render() {
     const {formState} = this.props.link;
     const {shouldShowError} = this.context;
@@ -181,8 +158,7 @@ export default class ObjectField<T: {}> extends React.Component<
       this.props.link.path,
       this.props.link.formState,
       this._handleChildChange,
-      this._handleChildBlur,
-      this._handleChildValidation
+      this._handleChildBlur
     );
     return (
       <React.Fragment>

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -126,7 +126,8 @@ export default class ObjectField<T: {}> extends React.Component<
       // TODO(zach): It's kind of gross that this is happening outside of Form.
       const nextFormState = changedFormState(customValue);
 
-      // Sibling nodes changed, so validate the entire subtree.
+      // A custom change occurred, which means the whole object needs to be
+      // revalidated.
       validatedFormState = this.context.validateFormStateAtPath(
         this.props.link.path,
         nextFormState

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -89,7 +89,7 @@ export default class ObjectField<T: {}> extends React.Component<
 
   componentDidUpdate(prevProps: Props<T>) {
     if (prevProps.validation !== this.props.validation) {
-      this.validationFnOps.replace(prevProps.validation, this.props.validation);
+      this.validationFnOps.replace(this.props.validation);
     }
   }
 

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -12,11 +12,9 @@ import type {
 import {FormContext, type ValidationOps, validationFnNoops} from "./Form";
 import {
   type FormState,
-  setChanged,
   replaceObjectChild,
   setExtrasTouched,
   objectChild,
-  setValidationResult,
   getExtras,
   flatRootErrors,
   isValid,
@@ -122,17 +120,15 @@ export default class ObjectField<T: {}> extends React.Component<
 
       // A custom change occurred, which means the whole object needs to be
       // revalidated.
-      validatedFormState = this.context.validateFormStateAtPath(
+      validatedFormState = this.context.applyValidationToTreeAtPath(
         this.props.link.path,
         nextFormState
       );
     } else {
-      const errors = this.context.validateAtPath(
+      validatedFormState = this.context.applyValidationAtPath(
         this.props.link.path,
-        newValue
+        newFormState
       );
-      const nextFormState = setChanged(newFormState);
-      validatedFormState = setValidationResult(errors, nextFormState);
     }
     this.props.link.onChange(validatedFormState);
   };

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -9,7 +9,7 @@ import type {
   AdditionalRenderInfo,
   CustomChange,
 } from "./types";
-import {FormContext, type ValidationOps, validationFnNoops} from "./Form";
+import {FormContext, type ValidationOps, validationFnNoOps} from "./Form";
 import {
   type FormState,
   replaceObjectChild,
@@ -76,7 +76,7 @@ export default class ObjectField<T: {}> extends React.Component<
     validation: () => [],
   };
 
-  validationFnOps: ValidationOps<T> = validationFnNoops();
+  validationFnOps: ValidationOps<T> = validationFnNoOps();
 
   componentDidMount() {
     this.validationFnOps = this.context.registerValidation(
@@ -93,7 +93,7 @@ export default class ObjectField<T: {}> extends React.Component<
 
   componentWillUnmount() {
     this.validationFnOps.unregister();
-    this.validationFnOps = validationFnNoops();
+    this.validationFnOps = validationFnNoOps();
   }
 
   _handleChildChange: <V>(string, FormState<V>) => void = <V>(

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -18,7 +18,6 @@ import {
   getExtras,
   flatRootErrors,
   isValid,
-  changedFormState,
 } from "./formState";
 import {
   type ShapedTree,
@@ -108,24 +107,19 @@ export default class ObjectField<T: {}> extends React.Component<
 
     const oldValue = this.props.link.formState[0];
     const newValue = newFormState[0];
-
     const customValue =
       this.props.customChange && this.props.customChange(oldValue, newValue);
 
     let validatedFormState: FormState<T>;
     if (customValue) {
-      // Create a fresh form state for the new value.
-      // TODO(zach): It's kind of gross that this is happening outside of Form.
-      const nextFormState = changedFormState(customValue);
-
       // A custom change occurred, which means the whole object needs to be
       // revalidated.
-      validatedFormState = this.context.applyValidationToTreeAtPath(
-        this.props.link.path,
-        nextFormState
-      );
+      validatedFormState = this.context.updateTreeAtPath(this.props.link.path, [
+        customValue,
+        newFormState[1],
+      ]);
     } else {
-      validatedFormState = this.context.applyValidationAtPath(
+      validatedFormState = this.context.updateNodeAtPath(
         this.props.link.path,
         newFormState
       );

--- a/src/formState.js
+++ b/src/formState.js
@@ -15,7 +15,7 @@ import {
   treeFromValue,
 } from "./shapedTree";
 import {cleanMeta, cleanErrors} from "./types";
-import type {Extras, ClientErrors, Validation, ServerErrors} from "./types";
+import type {Extras, ServerErrors} from "./types";
 import {replaceAt} from "./utils/array";
 import invariant from "./utils/invariant";
 
@@ -80,23 +80,22 @@ export function arrayChild<E>(
   return [value[index], shapedArrayChild(index, tree)];
 }
 
-export function validate<T>(
-  validation: Validation<T>,
+export function setValidationResult<T>(
+  errors: Array<string>,
   formState: FormState<T>
 ): FormState<T> {
   const [value, tree] = formState;
-  const newErrors = validation(value);
   return [
     value,
     mapRoot(
       ({meta}) => ({
         errors: {
-          client: newErrors,
+          client: errors,
           server: "unchecked",
         },
         meta: {
           ...meta,
-          succeeded: meta.succeeded || newErrors.length === 0,
+          succeeded: meta.succeeded || errors.length === 0,
         },
       }),
       tree
@@ -122,22 +121,6 @@ export function setTouched<T>(formState: FormState<T>): FormState<T> {
     formState[0],
     mapRoot(
       ({errors, meta}) => ({errors, meta: {...meta, touched: true}}),
-      formState[1]
-    ),
-  ];
-}
-
-export function setClientErrors<T>(
-  newErrors: ClientErrors,
-  formState: FormState<T>
-): FormState<T> {
-  return [
-    formState[0],
-    mapRoot(
-      ({errors, meta}) => ({
-        errors: {...errors, client: newErrors},
-        meta,
-      }),
       formState[1]
     ),
   ];

--- a/src/formState.js
+++ b/src/formState.js
@@ -80,42 +80,6 @@ export function arrayChild<E>(
   return [value[index], shapedArrayChild(index, tree)];
 }
 
-export function setValidationResult<T>(
-  errors: Array<string>,
-  formState: FormState<T>
-): FormState<T> {
-  const [value, tree] = formState;
-  return [
-    value,
-    mapRoot(
-      ({meta}) => ({
-        errors: {
-          client: errors,
-          server: "unchecked",
-        },
-        meta: {
-          ...meta,
-          succeeded: meta.succeeded || errors.length === 0,
-        },
-      }),
-      tree
-    ),
-  ];
-}
-
-export function setChanged<T>(formState: FormState<T>): FormState<T> {
-  return [
-    formState[0],
-    mapRoot(
-      ({errors, meta}) => ({
-        errors,
-        meta: {...meta, touched: true, changed: true},
-      }),
-      formState[1]
-    ),
-  ];
-}
-
 export function setTouched<T>(formState: FormState<T>): FormState<T> {
   return [
     formState[0],

--- a/src/formState.js
+++ b/src/formState.js
@@ -2,22 +2,18 @@
 
 import {
   type ShapedTree,
-  mapRoot,
   dangerouslyReplaceObjectChild,
   dangerouslyReplaceArrayChild,
   forgetShape,
-  dangerouslySetChildren,
   shapedObjectChild,
   shapedArrayChild,
-  shapedZipWith,
   foldMapShapedTree,
   getRootData,
   treeFromValue,
 } from "./shapedTree";
 import {cleanMeta, cleanErrors} from "./types";
-import type {Extras, ServerErrors} from "./types";
+import type {Extras} from "./types";
 import {replaceAt} from "./utils/array";
-import invariant from "./utils/invariant";
 
 // invariant, Tree is shaped like T
 export type FormState<T> = [T, ShapedTree<T, Extras>];
@@ -80,16 +76,6 @@ export function arrayChild<E>(
   return [value[index], shapedArrayChild(index, tree)];
 }
 
-export function setTouched<T>(formState: FormState<T>): FormState<T> {
-  return [
-    formState[0],
-    mapRoot(
-      ({errors, meta}) => ({errors, meta: {...meta, touched: true}}),
-      formState[1]
-    ),
-  ];
-}
-
 export function setExtrasTouched({errors, meta}: Extras): Extras {
   return {errors, meta: {...meta, touched: true}};
 }
@@ -117,110 +103,6 @@ export function replaceArrayChild<E>(
   return [
     replaceAt(index, childValue, value),
     dangerouslyReplaceArrayChild(index, childTree, tree),
-  ];
-}
-
-export function replaceArrayChildren<E>(
-  children: Array<FormState<E>>,
-  formState: FormState<Array<E>>
-): FormState<Array<E>> {
-  const [_, tree] = formState;
-  const [childValues, childTrees]: [
-    Array<E>,
-    Array<ShapedTree<E, Extras>>,
-  ] = children.reduce(
-    (memo, child) => {
-      const [childValue, childTree] = child;
-      return [memo[0].concat([childValue]), memo[1].concat([childTree])];
-    },
-    [[], []]
-  );
-  return [childValues, dangerouslySetChildren(childTrees, tree)];
-}
-
-function combineExtrasForValidation(oldExtras: Extras, newExtras: Extras) {
-  const {meta: oldMeta, errors: oldErrors} = oldExtras;
-  const {meta: newMeta, errors: newErrors} = newExtras;
-
-  // Only asyncValidationInFlight + succeeded may change
-  invariant(
-    oldMeta.touched === newMeta.touched,
-    "Recieved a new meta.touched when monoidally combining errors"
-  );
-  invariant(
-    oldMeta.changed === newMeta.changed,
-    "Recieved a new meta.changed when monoidally combining errors"
-  );
-
-  // No combination is possible if the old client errors are not pending
-  if (oldErrors.client !== "pending") {
-    return oldExtras;
-  }
-
-  // No combination is possible if the new client errors are pending
-  if (newErrors.client === "pending") {
-    return oldExtras;
-  }
-
-  return {
-    meta: {
-      touched: oldMeta.touched,
-      changed: oldMeta.changed,
-      succeeded: newMeta.succeeded,
-      asyncValidationInFlight:
-        oldMeta.asyncValidationInFlight || newMeta.asyncValidationInFlight,
-    },
-    errors: {
-      client: newErrors.client,
-      server: newErrors.server,
-    },
-  };
-}
-
-function monoidallyCombineTreesForValidation<T>(
-  oldTree: ShapedTree<T, Extras>,
-  newTree: ShapedTree<T, Extras>
-): ShapedTree<T, Extras> {
-  return shapedZipWith(combineExtrasForValidation, oldTree, newTree);
-}
-
-// Also sets asyncValidationInFlight
-export function monoidallyCombineFormStatesForValidation<T>(
-  oldState: FormState<T>,
-  newState: FormState<T>
-): FormState<T> {
-  // Value should never change when combining errors
-  invariant(
-    oldState[0] === newState[0],
-    "Received a new value when monoidally combining errors"
-  );
-
-  return [
-    oldState[0],
-    monoidallyCombineTreesForValidation(oldState[1], newState[1]),
-  ];
-}
-
-function replaceServerErrorsExtra(
-  newErrors: ServerErrors,
-  oldExtras: Extras
-): Extras {
-  const {meta, errors} = oldExtras;
-  return {
-    meta,
-    errors: {
-      client: errors.client,
-      server: newErrors,
-    },
-  };
-}
-export function replaceServerErrors<T>(
-  serverErrors: ShapedTree<T, ServerErrors>,
-  formState: FormState<T>
-): FormState<T> {
-  return [
-    formState[0],
-    shapedZipWith(replaceServerErrorsExtra, serverErrors, formState[1]),
   ];
 }
 

--- a/src/shapedTree.js
+++ b/src/shapedTree.js
@@ -1,13 +1,6 @@
 // @flow strict
 
-import {
-  type Tree,
-  type Path,
-  leaf,
-  strictZipWith,
-  mapTree,
-  foldMapTree,
-} from "./tree";
+import {type Tree, type Path, mapTree, foldMapTree} from "./tree";
 import invariant from "./utils/invariant";
 import {replaceAt} from "./utils/array";
 
@@ -203,37 +196,6 @@ export function updateAtPath<T, Node>(
   throw new Error("unreachable");
 }
 
-export function checkShape<T, Node>(
-  value: T,
-  tree: Tree<Node>
-): ShapedTree<T, Node> {
-  if (tree.type === "array") {
-    invariant(Array.isArray(value), "value isn't an array");
-    invariant(
-      value.length === tree.children.length,
-      "value and tree children have different lengths"
-    );
-    tree.children.forEach((child, i) => {
-      checkShape(value[i], child);
-    });
-  }
-  if (tree.type === "object") {
-    invariant(value instanceof Object, "value isn't an object in checkTree");
-    const valueEntries = Object.entries(value);
-    const childrenKeys = new Set(Object.keys(tree.children));
-    invariant(
-      valueEntries.length === childrenKeys.size,
-      "value doesn't have the right number of keys"
-    );
-    valueEntries.forEach(([key, value]) => {
-      invariant(childrenKeys.has(key));
-      checkShape(value, tree.children[key]);
-    });
-  }
-  // leaves are allowed to stand in for complex types in T
-  return tree;
-}
-
 export function shapedArrayChild<E, Node>(
   index: number,
   tree: ShapedTree<Array<E>, Node>
@@ -346,20 +308,6 @@ export function dangerouslySetChildren<E, Node>(
     data: tree.data,
     children: children.map(forgetShape),
   };
-}
-
-// A leaf matches any shape
-export function shapedLeaf<T, Node>(node: Node): ShapedTree<T, Node> {
-  return leaf(node);
-}
-
-export function shapedZipWith<T, A, B, C>(
-  f: (A, B) => C,
-  left: ShapedTree<T, A>,
-  right: ShapedTree<T, B>
-): ShapedTree<T, C> {
-  // Don't actually need the checks here if our invariant holds
-  return strictZipWith(f, left, right);
 }
 
 // Mapping doesn't change the shape

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -12,7 +12,7 @@ import TestField, {TestInput} from "./TestField";
 import {expectLink, mockLink, mockFormState} from "./tools";
 
 describe("ArrayField", () => {
-  describe("ArrayField is a field", () => {
+  describe("is a field", () => {
     it("ensures that the link inner type matches the type of the validation", () => {
       const formState = mockFormState(["one", "two", "three"]);
       const link = mockLink(formState);
@@ -56,6 +56,42 @@ describe("ArrayField", () => {
       expect(registerValidation).toBeCalledTimes(1);
       renderer.unmount();
       expect(unregister).toBeCalledTimes(1);
+    });
+
+    it("calls replace when changing the validation function", () => {
+      const replace = jest.fn();
+      const registerValidation = jest.fn(() => ({
+        replace,
+        unregister: jest.fn(),
+      }));
+
+      function TestForm() {
+        return (
+          <FormContext.Provider
+            value={{
+              shouldShowError: FeedbackStrategies.Always,
+              registerValidation,
+              validateFormStateAtPath: jest.fn(),
+              validateAtPath: jest.fn(),
+              pristine: true,
+              submitted: false,
+            }}
+          >
+            <ArrayField
+              link={mockLink(mockFormState(["hello", "world"]))}
+              validation={() => []}
+            >
+              {() => null}
+            </ArrayField>
+          </FormContext.Provider>
+        );
+      }
+
+      const renderer = TestRenderer.create(<TestForm />);
+      expect(registerValidation).toBeCalledTimes(1);
+
+      renderer.update(<TestForm />);
+      expect(replace).toBeCalledTimes(1);
     });
 
     it("Passes additional information to its render function", () => {

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -4,6 +4,7 @@ import * as React from "react";
 import TestRenderer from "react-test-renderer";
 import {FormContext} from "../Form";
 import FeedbackStrategies from "../feedbackStrategies";
+import Form from "../Form";
 import ArrayField from "../ArrayField";
 import {type FieldLink} from "../types";
 import TestField, {TestInput} from "./TestField";
@@ -12,133 +13,80 @@ import {expectLink, mockLink, mockFormState} from "./tools";
 
 describe("ArrayField", () => {
   describe("ArrayField is a field", () => {
-    describe("validates on mount", () => {
-      it("ensures that the link inner type matches the type of the validation", () => {
-        const formState = mockFormState(["one", "two", "three"]);
-        const link = mockLink(formState);
+    it("ensures that the link inner type matches the type of the validation", () => {
+      const formState = mockFormState(["one", "two", "three"]);
+      const link = mockLink(formState);
 
-        // $ExpectError
-        <ArrayField link={link} validation={(_e: empty) => []}>
-          {() => null}
-        </ArrayField>;
+      // $ExpectError
+      <ArrayField link={link} validation={(_e: empty) => []}>
+        {() => null}
+      </ArrayField>;
 
-        <ArrayField link={link} validation={(_e: Array<string>) => []}>
-          {() => null}
-        </ArrayField>;
-      });
+      <ArrayField link={link} validation={(_e: Array<string>) => []}>
+        {() => null}
+      </ArrayField>;
+    });
 
-      it("Registers and unregisters for validation", () => {
-        const formState = mockFormState([]);
-        const link = mockLink(formState);
-        const unregister = jest.fn();
-        const registerValidation = jest.fn(() => unregister);
+    it("Registers and unregisters for validation", () => {
+      const formState = mockFormState([]);
+      const link = mockLink(formState);
+      const unregister = jest.fn();
+      const registerValidation = jest.fn(() => ({
+        replace: jest.fn(),
+        unregister,
+      }));
 
-        const renderer = TestRenderer.create(
-          <FormContext.Provider
-            value={{
-              shouldShowError: FeedbackStrategies.Always,
-              registerValidation,
-              validateFormStateAtPath: jest.fn(),
-              pristine: true,
-              submitted: false,
-            }}
-          >
-            <ArrayField link={link} validation={jest.fn(() => [])}>
-              {jest.fn(() => null)}
-            </ArrayField>
-          </FormContext.Provider>
-        );
-
-        expect(registerValidation).toBeCalledTimes(1);
-        renderer.unmount();
-        expect(unregister).toBeCalledTimes(1);
-      });
-
-      it("Sets errors.client and meta.succeeded when there are no errors", () => {
-        const validation = jest.fn(() => []);
-        const formState = mockFormState([]);
-        const link = mockLink(formState);
-
-        TestRenderer.create(
-          <ArrayField link={link} validation={validation}>
+      const renderer = TestRenderer.create(
+        <FormContext.Provider
+          value={{
+            shouldShowError: FeedbackStrategies.Always,
+            registerValidation,
+            validateFormStateAtPath: jest.fn(),
+            validateAtPath: jest.fn(),
+            pristine: true,
+            submitted: false,
+          }}
+        >
+          <ArrayField link={link} validation={jest.fn(() => [])}>
             {jest.fn(() => null)}
           </ArrayField>
-        );
+        </FormContext.Provider>
+      );
 
-        expect(validation).toHaveBeenCalledTimes(1);
-        expect(validation).toHaveBeenCalledWith(formState[0]);
-        expect(link.onValidation).toHaveBeenCalledTimes(1);
+      expect(registerValidation).toBeCalledTimes(1);
+      renderer.unmount();
+      expect(unregister).toBeCalledTimes(1);
+    });
 
-        const [path, errors] = link.onValidation.mock.calls[0];
-        expect(path).toEqual([]);
-        expect(errors).toEqual([]);
-      });
+    it("Passes additional information to its render function", () => {
+      const formState = mockFormState(["value"]);
+      // $FlowFixMe
+      formState[1].data.errors = {
+        server: ["A server error"],
+        client: ["A client error"],
+      };
+      const link = mockLink(formState);
+      const renderFn = jest.fn(() => null);
 
-      it("Sets errors.client and meta.succeeded when there are errors", () => {
-        const validation = jest.fn(() => ["This is an error", "another error"]);
-        const formState = mockFormState([]);
-        const link = mockLink(formState);
+      TestRenderer.create(<ArrayField link={link}>{renderFn}</ArrayField>);
 
-        TestRenderer.create(
-          <ArrayField link={link} validation={validation}>
-            {jest.fn(() => null)}
-          </ArrayField>
-        );
-
-        expect(validation).toHaveBeenCalledTimes(1);
-        expect(validation).toHaveBeenCalledWith(formState[0]);
-        expect(link.onValidation).toHaveBeenCalledTimes(1);
-
-        const [path, errors] = link.onValidation.mock.calls[0];
-        expect(path).toEqual([]);
-        expect(errors).toEqual(["This is an error", "another error"]);
-      });
-
-      it("Treats no validation as always passing", () => {
-        const formState = mockFormState([]);
-        const link = mockLink(formState);
-
-        TestRenderer.create(
-          <ArrayField link={link}>{jest.fn(() => null)}</ArrayField>
-        );
-
-        expect(link.onValidation).toHaveBeenCalledTimes(1);
-
-        const [path, errors] = link.onValidation.mock.calls[0];
-        expect(path).toEqual([]);
-        expect(errors).toEqual([]);
-      });
-
-      it("Passes additional information to its render function", () => {
-        const formState = mockFormState(["value"]);
-        // $FlowFixMe
-        formState[1].data.errors = {
-          server: ["A server error"],
-          client: ["A client error"],
-        };
-        const link = mockLink(formState);
-        const renderFn = jest.fn(() => null);
-
-        TestRenderer.create(<ArrayField link={link}>{renderFn}</ArrayField>);
-
-        expect(renderFn).toHaveBeenCalled();
-        expect(renderFn).toHaveBeenCalledWith(
-          expect.anything(),
-          expect.anything(),
-          expect.objectContaining({
-            touched: false,
-            changed: false,
-            shouldShowErrors: expect.anything(),
-            unfilteredErrors: expect.arrayContaining([
-              "A server error",
-              "A client error",
-            ]),
-            valid: false,
-            asyncValidationInFlight: false,
-            value: ["value"],
-          })
-        );
-      });
+      expect(renderFn).toHaveBeenCalled();
+      expect(renderFn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          touched: false,
+          changed: false,
+          shouldShowErrors: expect.anything(),
+          unfilteredErrors: expect.arrayContaining([
+            "A server error",
+            "A client error",
+          ]),
+          valid: false,
+          asyncValidationInFlight: false,
+          value: ["value"],
+        })
+      );
     });
   });
 
@@ -220,35 +168,18 @@ describe("ArrayField", () => {
       expect(newArrayTree.children[0]).toBe(newElementTree);
     });
 
-    it("calls onValidation when a child initially validates", () => {
-      const formStateValue = ["one", "two", "three"];
-      const formState = mockFormState(formStateValue);
-      const link = mockLink(formState);
-      const renderFn = jest.fn(() => null);
-
-      TestRenderer.create(<ArrayField link={link}>{renderFn}</ArrayField>);
-
-      const arrayLinks = renderFn.mock.calls[0][0];
-      arrayLinks[2].onValidation([], ["These are", "some errors"]);
-
-      expect(link.onValidation).toHaveBeenCalledTimes(2);
-      // Important: the first call to onValidation is for the initial render validation
-      const [path, errors] = link.onValidation.mock.calls[1];
-      expect(path).toEqual([{type: "array", index: 2}]);
-      expect(errors).toEqual(["These are", "some errors"]);
-    });
-
     it("calls its validation when a child changes", () => {
-      const formStateValue = ["one", "two", "three"];
-      const formState = mockFormState(formStateValue);
-      const link = mockLink(formState);
       const renderFn = jest.fn(() => null);
       const validation = jest.fn(() => ["This is an error"]);
 
       TestRenderer.create(
-        <ArrayField link={link} validation={validation}>
-          {renderFn}
-        </ArrayField>
+        <Form initialValue={["one", "two", "three"]}>
+          {link => (
+            <ArrayField link={link} validation={validation}>
+              {renderFn}
+            </ArrayField>
+          )}
+        </Form>
       );
 
       expect(validation).toHaveBeenCalledTimes(1);
@@ -281,16 +212,17 @@ describe("ArrayField", () => {
         );
       });
       it("validates after entry is added", () => {
-        const formStateValue = ["one", "two", "three"];
-        const formState = mockFormState(formStateValue);
-        const link = mockLink(formState);
         const renderFn = jest.fn(() => null);
         const validation = jest.fn(() => ["an error"]);
 
         TestRenderer.create(
-          <ArrayField validation={validation} link={link}>
-            {renderFn}
-          </ArrayField>
+          <Form initialValue={["one", "two", "three"]}>
+            {link => (
+              <ArrayField validation={validation} link={link}>
+                {renderFn}
+              </ArrayField>
+            )}
+          </Form>
         );
 
         expect(validation).toHaveBeenCalledTimes(1);
@@ -326,16 +258,17 @@ describe("ArrayField", () => {
         );
       });
       it("validates after entry is removed", () => {
-        const formStateValue = ["one", "two", "three"];
-        const formState = mockFormState(formStateValue);
-        const link = mockLink(formState);
         const renderFn = jest.fn(() => null);
         const validation = jest.fn(() => ["an error"]);
 
         TestRenderer.create(
-          <ArrayField validation={validation} link={link}>
-            {renderFn}
-          </ArrayField>
+          <Form initialValue={["one", "two", "three"]}>
+            {link => (
+              <ArrayField validation={validation} link={link}>
+                {renderFn}
+              </ArrayField>
+            )}
+          </Form>
         );
 
         expect(validation).toHaveBeenCalledTimes(1);
@@ -366,16 +299,17 @@ describe("ArrayField", () => {
         );
       });
       it("validates after the entry is moved", () => {
-        const formStateValue = ["one", "two", "three"];
-        const formState = mockFormState(formStateValue);
-        const link = mockLink(formState);
         const renderFn = jest.fn(() => null);
         const validation = jest.fn(() => ["an error"]);
 
         TestRenderer.create(
-          <ArrayField validation={validation} link={link}>
-            {renderFn}
-          </ArrayField>
+          <Form initialValue={["one", "two", "three"]}>
+            {link => (
+              <ArrayField validation={validation} link={link}>
+                {renderFn}
+              </ArrayField>
+            )}
+          </Form>
         );
 
         expect(validation).toHaveBeenCalledTimes(1);
@@ -406,16 +340,17 @@ describe("ArrayField", () => {
         );
       });
       it("validates after fields are added", () => {
-        const formStateValue = ["one", "two", "three"];
-        const formState = mockFormState(formStateValue);
-        const link = mockLink(formState);
         const renderFn = jest.fn(() => null);
         const validation = jest.fn(() => ["an error"]);
 
         TestRenderer.create(
-          <ArrayField validation={validation} link={link}>
-            {renderFn}
-          </ArrayField>
+          <Form initialValue={["one", "two", "three"]}>
+            {link => (
+              <ArrayField validation={validation} link={link}>
+                {renderFn}
+              </ArrayField>
+            )}
+          </Form>
         );
 
         expect(validation).toHaveBeenCalledTimes(1);
@@ -454,16 +389,17 @@ describe("ArrayField", () => {
         );
       });
       it("validates after fields are filtered", () => {
-        const formStateValue = ["one", "two", "three", "four", "five"];
-        const formState = mockFormState(formStateValue);
-        const link = mockLink(formState);
         const renderFn = jest.fn(() => null);
         const validation = jest.fn(() => ["an error"]);
 
         TestRenderer.create(
-          <ArrayField validation={validation} link={link}>
-            {renderFn}
-          </ArrayField>
+          <Form initialValue={["one", "two", "three"]}>
+            {link => (
+              <ArrayField validation={validation} link={link}>
+                {renderFn}
+              </ArrayField>
+            )}
+          </Form>
         );
 
         expect(validation).toHaveBeenCalledTimes(1);
@@ -495,16 +431,17 @@ describe("ArrayField", () => {
         );
       });
       it("validates after fields are modified", () => {
-        const formStateValue = ["one", "two", "three"];
-        const formState = mockFormState(formStateValue);
-        const link = mockLink(formState);
         const renderFn = jest.fn(() => null);
         const validation = jest.fn(() => ["an error"]);
 
         TestRenderer.create(
-          <ArrayField validation={validation} link={link}>
-            {renderFn}
-          </ArrayField>
+          <Form initialValue={["one", "two", "three"]}>
+            {link => (
+              <ArrayField validation={validation} link={link}>
+                {renderFn}
+              </ArrayField>
+            )}
+          </Form>
         );
 
         expect(validation).toHaveBeenCalledTimes(1);
@@ -549,6 +486,7 @@ describe("ArrayField", () => {
             validateFormStateAtPath: jest.fn(
               (_subtreePath, formState) => formState
             ),
+            validateAtPath: jest.fn(),
             pristine: true,
             submitted: false,
           }}
@@ -584,22 +522,23 @@ describe("ArrayField", () => {
     });
 
     it("can return null to signal there was no custom change", () => {
-      const formStateInner = ["one", "two", "three"];
-      const formState = mockFormState(formStateInner);
-      const link = mockLink(formState);
-      const renderFn = jest.fn(() => null);
-      const validation = jest.fn(() => ["This is an error"]);
-
       const customChange = jest.fn((_oldValue, _newValue) => null);
 
-      TestRenderer.create(
-        <ArrayField
-          link={link}
-          validation={validation}
-          customChange={customChange}
-        >
-          {renderFn}
-        </ArrayField>
+      const renderFn = jest.fn(() => null);
+      const validation = jest.fn(() => ["an error"]);
+
+      const renderer = TestRenderer.create(
+        <Form initialValue={["one", "two", "three"]}>
+          {link => (
+            <ArrayField
+              validation={validation}
+              link={link}
+              customChange={customChange}
+            >
+              {renderFn}
+            </ArrayField>
+          )}
+        </Form>
       );
 
       const arrayLinks = renderFn.mock.calls[0][0];
@@ -610,8 +549,8 @@ describe("ArrayField", () => {
       expect(customChange).toHaveBeenCalledTimes(1);
 
       // onChange should be called with the result of customChange
-      expect(link.onChange).toHaveBeenCalledTimes(1);
-      expect(link.onChange).toHaveBeenCalledWith([
+      const link = renderer.root.findByType(ArrayField).instance.props.link;
+      expect(link.formState).toEqual([
         ["one", "zwei", "three"],
         expect.anything(),
       ]);
@@ -622,57 +561,56 @@ describe("ArrayField", () => {
     });
 
     it("doesn't break validations for child fields", () => {
-      const formStateInner = ["one", "two", "three"];
-      const formState = mockFormState(formStateInner);
-      const link = mockLink(formState);
-      const validateFormStateAtPath = jest.fn(
-        (_subtreePath, formState) => formState
-      );
       const customChange = jest.fn((_oldValue, _newValue) => ["1", "2"]);
 
       const childValidation = jest.fn(() => ["This is an error"]);
+      const parentValidation = jest.fn(() => [
+        "This is an error from the parent",
+      ]);
 
       const renderer = TestRenderer.create(
-        <FormContext.Provider
-          value={{
-            shouldShowError: FeedbackStrategies.Always,
-            registerValidation: jest.fn(),
-            validateFormStateAtPath,
-            pristine: true,
-            submitted: false,
-          }}
-        >
-          <ArrayField link={link} customChange={customChange}>
-            {links => (
-              <React.Fragment>
-                {links.map((link, i) => (
-                  <TestField key={i} link={link} validation={childValidation} />
-                ))}
-              </React.Fragment>
-            )}
-          </ArrayField>
-        </FormContext.Provider>
+        <Form initialValue={["1", "2"]}>
+          {link => (
+            <ArrayField
+              link={link}
+              customChange={customChange}
+              validation={parentValidation}
+            >
+              {links => (
+                <React.Fragment>
+                  {links.map((link, i) => (
+                    <TestField
+                      key={i}
+                      link={link}
+                      validation={childValidation}
+                    />
+                  ))}
+                </React.Fragment>
+              )}
+            </ArrayField>
+          )}
+        </Form>
       );
 
-      // 6 validations:
-      // 1) Child initial validation x3
-      // 2) Parent initial validation
-      // 3) Subtree upon customChange
-      // (No parent onValidation call, because it will use onChange)
+      // after mount, validate everything
+      expect(parentValidation).toHaveBeenCalledTimes(1);
+      expect(childValidation).toHaveBeenCalledTimes(2);
 
-      // 1) and 2)
-      expect(link.onValidation).toHaveBeenCalledTimes(4);
-      link.onValidation.mockClear();
-
+      // Now change one of the values
+      parentValidation.mockClear();
+      childValidation.mockClear();
       const inner = renderer.root.findAllByType(TestInput)[0];
       inner.instance.change("zach");
 
-      // 3)
-      expect(validateFormStateAtPath).toHaveBeenCalledTimes(1);
-      expect(validateFormStateAtPath).toHaveBeenCalledWith(
-        [], // The Array is at the root, so empty path
-        [["1", "2"], expect.anything()]
-      );
+      // Validate the whole subtree due to the customChange child validates
+      // once. Note that child validation will be called 3 times. Once after the
+      // change, then twice more after the customChange triggers a validation fo
+      // the entire subtree.
+      expect(parentValidation).toHaveBeenCalledTimes(1);
+      expect(childValidation).toHaveBeenCalledTimes(1 + 2);
+
+      const link = renderer.root.findByType(ArrayField).instance.props.link;
+      expect(link.formState).toEqual([["1", "2"], expect.anything()]);
     });
 
     it("doesn't create a new instance (i.e. remount)", () => {

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -2,12 +2,11 @@
 
 import * as React from "react";
 import TestRenderer from "react-test-renderer";
-import {FormContext} from "../Form";
-import FeedbackStrategies from "../feedbackStrategies";
 import Form from "../Form";
 import ArrayField from "../ArrayField";
 import {type FieldLink} from "../types";
 import TestField, {TestInput} from "./TestField";
+import TestForm from "./TestForm";
 
 import {expectLink, mockLink, mockFormState} from "./tools";
 
@@ -37,20 +36,11 @@ describe("ArrayField", () => {
       }));
 
       const renderer = TestRenderer.create(
-        <FormContext.Provider
-          value={{
-            shouldShowError: FeedbackStrategies.Always,
-            registerValidation,
-            validateFormStateAtPath: jest.fn(),
-            validateAtPath: jest.fn(),
-            pristine: true,
-            submitted: false,
-          }}
-        >
-          <ArrayField link={link} validation={jest.fn(() => [])}>
-            {jest.fn(() => null)}
+        <TestForm registerValidation={registerValidation}>
+          <ArrayField link={link} validation={() => []}>
+            {() => null}
           </ArrayField>
-        </FormContext.Provider>
+        </TestForm>
       );
 
       expect(registerValidation).toBeCalledTimes(1);
@@ -65,32 +55,23 @@ describe("ArrayField", () => {
         unregister: jest.fn(),
       }));
 
-      function TestForm() {
+      function Component() {
         return (
-          <FormContext.Provider
-            value={{
-              shouldShowError: FeedbackStrategies.Always,
-              registerValidation,
-              validateFormStateAtPath: jest.fn(),
-              validateAtPath: jest.fn(),
-              pristine: true,
-              submitted: false,
-            }}
-          >
+          <TestForm registerValidation={registerValidation}>
             <ArrayField
               link={mockLink(mockFormState(["hello", "world"]))}
               validation={() => []}
             >
               {() => null}
             </ArrayField>
-          </FormContext.Provider>
+          </TestForm>
         );
       }
 
-      const renderer = TestRenderer.create(<TestForm />);
+      const renderer = TestRenderer.create(<Component />);
       expect(registerValidation).toBeCalledTimes(1);
 
-      renderer.update(<TestForm />);
+      renderer.update(<Component />);
       expect(replace).toBeCalledTimes(1);
     });
 
@@ -515,18 +496,7 @@ describe("ArrayField", () => {
       ]);
 
       TestRenderer.create(
-        <FormContext.Provider
-          value={{
-            shouldShowError: FeedbackStrategies.Always,
-            registerValidation: jest.fn(),
-            validateFormStateAtPath: jest.fn(
-              (_subtreePath, formState) => formState
-            ),
-            validateAtPath: jest.fn(),
-            pristine: true,
-            submitted: false,
-          }}
-        >
+        <TestForm>
           <ArrayField
             link={link}
             validation={validation}
@@ -534,7 +504,7 @@ describe("ArrayField", () => {
           >
             {renderFn}
           </ArrayField>
-        </FormContext.Provider>
+        </TestForm>
       );
 
       const arrayLinks = renderFn.mock.calls[0][0];

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -287,9 +287,13 @@ describe("ArrayField", () => {
         );
       });
       it("validates after entry is removed", () => {
-        const renderFn = jest.fn(() => null);
+        const elementValidation = jest.fn(() => ["an element error"]);
+        const renderFn = jest.fn(links =>
+          links.map((link, i) => (
+            <TestField key={i} link={link} validation={elementValidation} />
+          ))
+        );
         const validation = jest.fn(() => ["an error"]);
-
         TestRenderer.create(
           <Form initialValue={["one", "two", "three"]}>
             {link => (

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -147,15 +147,15 @@ describe("ArrayField", () => {
       const link = mockLink(formState);
       const renderFn = jest.fn(() => null);
 
-      const applyValidationAtPath = jest.fn((path, formState) => formState);
+      const updateNodeAtPath = jest.fn((path, formState) => formState);
 
       TestRenderer.create(
-        <TestForm applyValidationAtPath={applyValidationAtPath}>
+        <TestForm updateNodeAtPath={updateNodeAtPath}>
           <ArrayField link={link}>{renderFn}</ArrayField>
         </TestForm>
       );
 
-      expect(applyValidationAtPath).toHaveBeenCalledTimes(0);
+      expect(updateNodeAtPath).toHaveBeenCalledTimes(0);
       expect(link.onChange).toHaveBeenCalledTimes(0);
 
       // call a child's onChange
@@ -163,8 +163,8 @@ describe("ArrayField", () => {
       const newElementFormState = mockFormState("newTwo");
       arrayLinks[1].onChange(newElementFormState);
 
-      expect(applyValidationAtPath).toHaveBeenCalledTimes(1);
-      expect(applyValidationAtPath).toHaveBeenCalledWith(
+      expect(updateNodeAtPath).toHaveBeenCalledTimes(1);
+      expect(updateNodeAtPath).toHaveBeenCalledWith(
         [],
         [["one", "newTwo", "three"], expect.anything()]
       );

--- a/src/test/Field.test.js
+++ b/src/test/Field.test.js
@@ -74,26 +74,35 @@ describe("Field", () => {
     expect(replace).toBeCalledTimes(1);
   });
 
-  it("calls the link onChange with new values and correct meta", () => {
+  it("validates new values and passes result to onChange", () => {
     const formState = mockFormState("Hello world.");
     const link = mockLink(formState);
 
-    const renderer = TestRenderer.create(<TestField link={link} />);
+    const applyValidationAtPath = jest.fn((path, formState) => formState);
+
+    const renderer = TestRenderer.create(
+      <TestForm applyValidationAtPath={applyValidationAtPath}>
+        <TestField link={link} />
+      </TestForm>
+    );
     const inner = renderer.root.findByType(TestInput);
 
+    expect(applyValidationAtPath).toHaveBeenCalledTimes(0);
     expect(link.onChange).toHaveBeenCalledTimes(0);
-    inner.instance.change("You've got mail");
-    expect(link.onChange).toHaveBeenCalledTimes(1);
 
-    const [value, tree] = link.onChange.mock.calls[0][0];
-    expect(value).toBe("You've got mail");
-    expect(tree.data).toMatchObject({
-      meta: {
-        touched: true,
-        changed: true,
-        succeeded: true,
-      },
-    });
+    inner.instance.change("You've got mail");
+
+    expect(applyValidationAtPath).toHaveBeenCalledTimes(1);
+    expect(applyValidationAtPath).toHaveBeenCalledWith(
+      [],
+      ["You've got mail", expect.anything()]
+    );
+
+    expect(link.onChange).toHaveBeenCalledTimes(1);
+    expect(link.onChange).toHaveBeenCalledWith([
+      "You've got mail",
+      formState[1],
+    ]);
   });
 
   it("calls the link onBlur with correct meta", () => {

--- a/src/test/Field.test.js
+++ b/src/test/Field.test.js
@@ -3,12 +3,11 @@
 import * as React from "react";
 import TestRenderer from "react-test-renderer";
 
-import {FormContext} from "../Form";
-import FeedbackStrategies from "../feedbackStrategies";
 import Field from "../Field";
 import {type FieldLink} from "../types";
 import {mockFormState, mockLink} from "./tools";
 import TestField, {TestInput} from "./TestField";
+import TestForm from "./TestForm";
 import {mapRoot} from "../shapedTree";
 
 describe("Field", () => {
@@ -36,20 +35,11 @@ describe("Field", () => {
     }));
 
     const renderer = TestRenderer.create(
-      <FormContext.Provider
-        value={{
-          shouldShowError: FeedbackStrategies.Always,
-          registerValidation,
-          validateFormStateAtPath: jest.fn(),
-          validateAtPath: jest.fn(),
-          pristine: true,
-          submitted: false,
-        }}
-      >
+      <TestForm registerValidation={registerValidation}>
         <Field link={link} validation={jest.fn(() => [])}>
           {jest.fn(() => null)}
         </Field>
-      </FormContext.Provider>
+      </TestForm>
     );
 
     expect(registerValidation).toBeCalledTimes(1);
@@ -64,32 +54,23 @@ describe("Field", () => {
       unregister: jest.fn(),
     }));
 
-    function TestForm() {
+    function Component() {
       return (
-        <FormContext.Provider
-          value={{
-            shouldShowError: FeedbackStrategies.Always,
-            registerValidation,
-            validateFormStateAtPath: jest.fn(),
-            validateAtPath: jest.fn(),
-            pristine: true,
-            submitted: false,
-          }}
-        >
+        <TestForm registerValidation={registerValidation}>
           <Field
             link={mockLink(mockFormState("Hello world."))}
             validation={() => []}
           >
             {() => null}
           </Field>
-        </FormContext.Provider>
+        </TestForm>
       );
     }
 
-    const renderer = TestRenderer.create(<TestForm />);
+    const renderer = TestRenderer.create(<Component />);
     expect(registerValidation).toBeCalledTimes(1);
 
-    renderer.update(<TestForm />);
+    renderer.update(<Component />);
     expect(replace).toBeCalledTimes(1);
   });
 

--- a/src/test/Field.test.js
+++ b/src/test/Field.test.js
@@ -12,90 +12,49 @@ import TestField, {TestInput} from "./TestField";
 import {mapRoot} from "../shapedTree";
 
 describe("Field", () => {
-  describe("validates on mount", () => {
-    it("ensures that the link inner type matches the type of the validation", () => {
-      const formState = mockFormState("Hello world.");
-      const link = mockLink(formState);
+  it("ensures that the link inner type matches the type of the validation", () => {
+    const formState = mockFormState("Hello world.");
+    const link = mockLink(formState);
 
-      // $ExpectError
-      <Field link={link} validation={(_e: empty) => []}>
-        {() => null}
-      </Field>;
+    // $ExpectError
+    <Field link={link} validation={(_e: empty) => []}>
+      {() => null}
+    </Field>;
 
-      <Field link={link} validation={(_e: string) => []}>
-        {() => null}
-      </Field>;
-    });
+    <Field link={link} validation={(_e: string) => []}>
+      {() => null}
+    </Field>;
+  });
 
-    it("Registers and unregisters for validation", () => {
-      const formState = mockFormState("Hello world.");
-      const link = mockLink(formState);
-      const unregister = jest.fn();
-      const registerValidation = jest.fn(() => unregister);
+  it("Registers and unregisters for validation", () => {
+    const formState = mockFormState("Hello world.");
+    const link = mockLink(formState);
+    const unregister = jest.fn();
+    const registerValidation = jest.fn(() => ({
+      replace: jest.fn(),
+      unregister,
+    }));
 
-      const renderer = TestRenderer.create(
-        <FormContext.Provider
-          value={{
-            shouldShowError: FeedbackStrategies.Always,
-            registerValidation,
-            validateFormStateAtPath: jest.fn(),
-            pristine: true,
-            submitted: false,
-          }}
-        >
-          <Field link={link} validation={jest.fn(() => [])}>
-            {jest.fn(() => null)}
-          </Field>
-        </FormContext.Provider>
-      );
+    const renderer = TestRenderer.create(
+      <FormContext.Provider
+        value={{
+          shouldShowError: FeedbackStrategies.Always,
+          registerValidation,
+          validateFormStateAtPath: jest.fn(),
+          validateAtPath: jest.fn(),
+          pristine: true,
+          submitted: false,
+        }}
+      >
+        <Field link={link} validation={jest.fn(() => [])}>
+          {jest.fn(() => null)}
+        </Field>
+      </FormContext.Provider>
+    );
 
-      expect(registerValidation).toBeCalledTimes(1);
-      renderer.unmount();
-      expect(unregister).toBeCalledTimes(1);
-    });
-
-    it("Sets errors.client and meta.succeeded when there are no errors", () => {
-      const formState = mockFormState("Hello world.");
-      const link = mockLink(formState);
-      const validation = jest.fn(() => []);
-
-      TestRenderer.create(<TestField link={link} validation={validation} />);
-
-      expect(validation).toHaveBeenCalledTimes(1);
-      expect(link.onValidation).toHaveBeenCalledTimes(1);
-
-      const [path, errors] = link.onValidation.mock.calls[0];
-      expect(path).toEqual([]);
-      expect(errors).toEqual([]);
-    });
-
-    it("Sets errors.client and meta.succeeded when there are errors", () => {
-      const formState = mockFormState("Hello world.");
-      const link = mockLink(formState);
-      const validation = jest.fn(() => ["This is an error"]);
-
-      TestRenderer.create(<TestField link={link} validation={validation} />);
-
-      expect(validation).toHaveBeenCalledTimes(1);
-      expect(link.onValidation).toHaveBeenCalledTimes(1);
-
-      const [path, errors] = link.onValidation.mock.calls[0];
-      expect(path).toEqual([]);
-      expect(errors).toEqual(["This is an error"]);
-    });
-
-    it("Counts as successfully validated if there is no validation", () => {
-      const formState = mockFormState("Hello world.");
-      const link = mockLink(formState);
-
-      TestRenderer.create(<TestField link={link} />);
-
-      expect(link.onValidation).toHaveBeenCalledTimes(1);
-
-      const [path, errors] = link.onValidation.mock.calls[0];
-      expect(path).toEqual([]);
-      expect(errors).toEqual([]);
-    });
+    expect(registerValidation).toBeCalledTimes(1);
+    renderer.unmount();
+    expect(unregister).toBeCalledTimes(1);
   });
 
   it("calls the link onChange with new values and correct meta", () => {

--- a/src/test/Field.test.js
+++ b/src/test/Field.test.js
@@ -3,6 +3,8 @@
 import * as React from "react";
 import TestRenderer from "react-test-renderer";
 
+import {FormContext} from "../Form";
+import FeedbackStrategies from "../feedbackStrategies";
 import Field from "../Field";
 import {type FieldLink} from "../types";
 import {mockFormState, mockLink} from "./tools";
@@ -23,6 +25,33 @@ describe("Field", () => {
       <Field link={link} validation={(_e: string) => []}>
         {() => null}
       </Field>;
+    });
+
+    it("Registers and unregisters for validation", () => {
+      const formState = mockFormState("Hello world.");
+      const link = mockLink(formState);
+      const unregister = jest.fn();
+      const registerValidation = jest.fn(() => unregister);
+
+      const renderer = TestRenderer.create(
+        <FormContext.Provider
+          value={{
+            shouldShowError: FeedbackStrategies.Always,
+            registerValidation,
+            validateFormStateAtPath: jest.fn(),
+            pristine: true,
+            submitted: false,
+          }}
+        >
+          <Field link={link} validation={jest.fn(() => [])}>
+            {jest.fn(() => null)}
+          </Field>
+        </FormContext.Provider>
+      );
+
+      expect(registerValidation).toBeCalledTimes(1);
+      renderer.unmount();
+      expect(unregister).toBeCalledTimes(1);
     });
 
     it("Sets errors.client and meta.succeeded when there are no errors", () => {

--- a/src/test/Field.test.js
+++ b/src/test/Field.test.js
@@ -26,7 +26,7 @@ describe("Field", () => {
     </Field>;
   });
 
-  it("Registers and unregisters for validation", () => {
+  it("registers and unregisters for validation", () => {
     const formState = mockFormState("Hello world.");
     const link = mockLink(formState);
     const unregister = jest.fn();
@@ -55,6 +55,42 @@ describe("Field", () => {
     expect(registerValidation).toBeCalledTimes(1);
     renderer.unmount();
     expect(unregister).toBeCalledTimes(1);
+  });
+
+  it("calls replace when changing the validation function", () => {
+    const replace = jest.fn();
+    const registerValidation = jest.fn(() => ({
+      replace,
+      unregister: jest.fn(),
+    }));
+
+    function TestForm() {
+      return (
+        <FormContext.Provider
+          value={{
+            shouldShowError: FeedbackStrategies.Always,
+            registerValidation,
+            validateFormStateAtPath: jest.fn(),
+            validateAtPath: jest.fn(),
+            pristine: true,
+            submitted: false,
+          }}
+        >
+          <Field
+            link={mockLink(mockFormState("Hello world."))}
+            validation={() => []}
+          >
+            {() => null}
+          </Field>
+        </FormContext.Provider>
+      );
+    }
+
+    const renderer = TestRenderer.create(<TestForm />);
+    expect(registerValidation).toBeCalledTimes(1);
+
+    renderer.update(<TestForm />);
+    expect(replace).toBeCalledTimes(1);
   });
 
   it("calls the link onChange with new values and correct meta", () => {

--- a/src/test/Field.test.js
+++ b/src/test/Field.test.js
@@ -78,22 +78,22 @@ describe("Field", () => {
     const formState = mockFormState("Hello world.");
     const link = mockLink(formState);
 
-    const applyValidationAtPath = jest.fn((path, formState) => formState);
+    const updateNodeAtPath = jest.fn((path, formState) => formState);
 
     const renderer = TestRenderer.create(
-      <TestForm applyValidationAtPath={applyValidationAtPath}>
+      <TestForm updateNodeAtPath={updateNodeAtPath}>
         <TestField link={link} />
       </TestForm>
     );
     const inner = renderer.root.findByType(TestInput);
 
-    expect(applyValidationAtPath).toHaveBeenCalledTimes(0);
+    expect(updateNodeAtPath).toHaveBeenCalledTimes(0);
     expect(link.onChange).toHaveBeenCalledTimes(0);
 
     inner.instance.change("You've got mail");
 
-    expect(applyValidationAtPath).toHaveBeenCalledTimes(1);
-    expect(applyValidationAtPath).toHaveBeenCalledWith(
+    expect(updateNodeAtPath).toHaveBeenCalledTimes(1);
+    expect(updateNodeAtPath).toHaveBeenCalledWith(
       [],
       ["You've got mail", expect.anything()]
     );

--- a/src/test/Form.test.js
+++ b/src/test/Form.test.js
@@ -265,6 +265,28 @@ describe("Form", () => {
       expect(validationB).toHaveBeenCalledTimes(1);
       expect(validationB).toHaveBeenCalledWith("hello");
     });
+
+    it("updates errors when a new validation function is provided via props", () => {
+      const renderer = TestRenderer.create(
+        <Form initialValue="hello">
+          {link => <TestField link={link} validation={() => ["error 1"]} />}
+        </Form>
+      );
+
+      let link = renderer.root.findAllByType(TestField)[0].instance.props.link;
+      let errors = link.formState[1].data.errors.client;
+      expect(errors).toEqual(["error 1"]);
+
+      renderer.update(
+        <Form initialValue="hello">
+          {link => <TestField link={link} validation={() => ["error 2"]} />}
+        </Form>
+      );
+
+      link = renderer.root.findAllByType(TestField)[0].instance.props.link;
+      errors = link.formState[1].data.errors.client;
+      expect(errors).toEqual(["error 2"]);
+    });
   });
 
   describe("Form manages form state", () => {
@@ -810,28 +832,6 @@ describe("Form", () => {
       errors = link.formState[1].data.errors.client;
       expect(errors).toEqual(["error 1"]);
     });
-  });
-
-  it("updates errors when a new validation function is provided via props", () => {
-    const renderer = TestRenderer.create(
-      <Form initialValue="hello">
-        {link => <TestField link={link} validation={() => ["error 1"]} />}
-      </Form>
-    );
-
-    let link = renderer.root.findAllByType(TestField)[0].instance.props.link;
-    let errors = link.formState[1].data.errors.client;
-    expect(errors).toEqual(["error 1"]);
-
-    renderer.update(
-      <Form initialValue="hello">
-        {link => <TestField link={link} validation={() => ["error 2"]} />}
-      </Form>
-    );
-
-    link = renderer.root.findAllByType(TestField)[0].instance.props.link;
-    errors = link.formState[1].data.errors.client;
-    expect(errors).toEqual(["error 2"]);
   });
 
   it("Calls onSubmit with the value when submitted", () => {

--- a/src/test/ObjectField.test.js
+++ b/src/test/ObjectField.test.js
@@ -18,7 +18,7 @@ describe("ObjectField", () => {
     });
   });
 
-  describe("ObjectField is a field", () => {
+  describe("is a field", () => {
     it("ensures that the link inner type matches the type of the validation", () => {
       type TestObject = {|
         string: string,
@@ -75,6 +75,42 @@ describe("ObjectField", () => {
       expect(registerValidation).toBeCalledTimes(1);
       renderer.unmount();
       expect(unregister).toBeCalledTimes(1);
+    });
+
+    it("calls replace when changing the validation function", () => {
+      const replace = jest.fn();
+      const registerValidation = jest.fn(() => ({
+        replace,
+        unregister: jest.fn(),
+      }));
+
+      function TestForm() {
+        return (
+          <FormContext.Provider
+            value={{
+              shouldShowError: FeedbackStrategies.Always,
+              registerValidation,
+              validateFormStateAtPath: jest.fn(),
+              validateAtPath: jest.fn(),
+              pristine: true,
+              submitted: false,
+            }}
+          >
+            <ObjectField
+              link={mockLink(mockFormState({hello: "world"}))}
+              validation={() => []}
+            >
+              {() => null}
+            </ObjectField>
+          </FormContext.Provider>
+        );
+      }
+
+      const renderer = TestRenderer.create(<TestForm />);
+      expect(registerValidation).toBeCalledTimes(1);
+
+      renderer.update(<TestForm />);
+      expect(replace).toBeCalledTimes(1);
     });
 
     it("Passes additional information to its render function", () => {

--- a/src/test/ObjectField.test.js
+++ b/src/test/ObjectField.test.js
@@ -3,13 +3,13 @@
 import * as React from "react";
 import TestRenderer from "react-test-renderer";
 import {FormContext} from "../Form";
-import FeedbackStrategies from "../feedbackStrategies";
 import ObjectField from "../ObjectField";
 import Form from "../Form";
 import {type FieldLink} from "../types";
 
 import {expectLink, mockLink, mockFormState} from "./tools";
 import TestField, {TestInput} from "./TestField";
+import TestForm from "./TestForm";
 
 describe("ObjectField", () => {
   describe("Sneaky hacks", () => {
@@ -56,20 +56,11 @@ describe("ObjectField", () => {
       }));
 
       const renderer = TestRenderer.create(
-        <FormContext.Provider
-          value={{
-            shouldShowError: FeedbackStrategies.Always,
-            registerValidation,
-            validateFormStateAtPath: jest.fn(),
-            validateAtPath: jest.fn(),
-            pristine: true,
-            submitted: false,
-          }}
-        >
+        <TestForm registerValidation={registerValidation}>
           <ObjectField link={link} validation={jest.fn(() => [])}>
             {jest.fn(() => null)}
           </ObjectField>
-        </FormContext.Provider>
+        </TestForm>
       );
 
       expect(registerValidation).toBeCalledTimes(1);
@@ -84,32 +75,23 @@ describe("ObjectField", () => {
         unregister: jest.fn(),
       }));
 
-      function TestForm() {
+      function Component() {
         return (
-          <FormContext.Provider
-            value={{
-              shouldShowError: FeedbackStrategies.Always,
-              registerValidation,
-              validateFormStateAtPath: jest.fn(),
-              validateAtPath: jest.fn(),
-              pristine: true,
-              submitted: false,
-            }}
-          >
+          <TestForm registerValidation={registerValidation}>
             <ObjectField
               link={mockLink(mockFormState({hello: "world"}))}
               validation={() => []}
             >
               {() => null}
             </ObjectField>
-          </FormContext.Provider>
+          </TestForm>
         );
       }
 
-      const renderer = TestRenderer.create(<TestForm />);
+      const renderer = TestRenderer.create(<Component />);
       expect(registerValidation).toBeCalledTimes(1);
 
-      renderer.update(<TestForm />);
+      renderer.update(<Component />);
       expect(replace).toBeCalledTimes(1);
     });
 
@@ -303,18 +285,7 @@ describe("ObjectField", () => {
       }));
 
       TestRenderer.create(
-        <FormContext.Provider
-          value={{
-            shouldShowError: FeedbackStrategies.Always,
-            registerValidation: jest.fn(),
-            validateFormStateAtPath: jest.fn(
-              (_subtreePath, formState) => formState
-            ),
-            validateAtPath: jest.fn(),
-            pristine: true,
-            submitted: false,
-          }}
-        >
+        <TestForm>
           <ObjectField
             link={link}
             validation={jest.fn(() => ["This is an error"])}
@@ -322,7 +293,7 @@ describe("ObjectField", () => {
           >
             {renderFn}
           </ObjectField>
-        </FormContext.Provider>
+        </TestForm>
       );
 
       const objectLinks = renderFn.mock.calls[0][0];

--- a/src/test/ObjectField.test.js
+++ b/src/test/ObjectField.test.js
@@ -193,15 +193,15 @@ describe("ObjectField", () => {
       const link = mockLink(formState);
       const renderFn = jest.fn(() => null);
 
-      const applyValidationAtPath = jest.fn((path, formState) => formState);
+      const updateNodeAtPath = jest.fn((path, formState) => formState);
 
       TestRenderer.create(
-        <TestForm applyValidationAtPath={applyValidationAtPath}>
+        <TestForm updateNodeAtPath={updateNodeAtPath}>
           <ObjectField link={link}>{renderFn}</ObjectField>
         </TestForm>
       );
 
-      expect(applyValidationAtPath).toHaveBeenCalledTimes(0);
+      expect(updateNodeAtPath).toHaveBeenCalledTimes(0);
       expect(link.onChange).toHaveBeenCalledTimes(0);
 
       // call the child onChange
@@ -209,8 +209,8 @@ describe("ObjectField", () => {
       const newChildMeta = mockFormState("newString");
       objectLinks.string.onChange(newChildMeta);
 
-      expect(applyValidationAtPath).toHaveBeenCalledTimes(1);
-      expect(applyValidationAtPath).toHaveBeenCalledWith(
+      expect(updateNodeAtPath).toHaveBeenCalledTimes(1);
+      expect(updateNodeAtPath).toHaveBeenCalledWith(
         [],
         [{string: "newString", number: 42}, expect.anything()]
       );

--- a/src/test/TestForm.js
+++ b/src/test/TestForm.js
@@ -5,7 +5,7 @@ import * as React from "react";
 import {FormContext, type FormContextPayload} from "../Form";
 
 type Props = {
-  ...FormContextPayload,
+  ...$Shape<{...FormContextPayload}>,
   children: React.Node,
 };
 
@@ -15,8 +15,8 @@ export default function TestForm({
   pristine = false,
   submitted = true,
   registerValidation = () => ({replace: () => {}, unregister: () => {}}),
-  validateFormStateAtPath = (path, x) => x,
-  validateAtPath = () => [],
+  applyValidationToTreeAtPath = (path, formState) => formState,
+  applyValidationAtPath = (path, formState) => formState,
 }: Props = {}) {
   return (
     <FormContext.Provider
@@ -25,8 +25,8 @@ export default function TestForm({
         pristine,
         submitted,
         registerValidation,
-        validateFormStateAtPath,
-        validateAtPath,
+        applyValidationToTreeAtPath,
+        applyValidationAtPath,
       }}
     >
       {children}

--- a/src/test/TestForm.js
+++ b/src/test/TestForm.js
@@ -1,0 +1,35 @@
+// @flow
+
+import * as React from "react";
+
+import {FormContext, type FormContextPayload} from "../Form";
+
+type Props = {
+  ...FormContextPayload,
+  children: React.Node,
+};
+
+export default function TestForm({
+  children,
+  shouldShowError = () => true,
+  pristine = false,
+  submitted = true,
+  registerValidation = () => ({replace: () => {}, unregister: () => {}}),
+  validateFormStateAtPath = (path, x) => x,
+  validateAtPath = () => [],
+}: Props = {}) {
+  return (
+    <FormContext.Provider
+      value={{
+        shouldShowError,
+        pristine,
+        submitted,
+        registerValidation,
+        validateFormStateAtPath,
+        validateAtPath,
+      }}
+    >
+      {children}
+    </FormContext.Provider>
+  );
+}

--- a/src/test/TestForm.js
+++ b/src/test/TestForm.js
@@ -15,8 +15,8 @@ export default function TestForm({
   pristine = false,
   submitted = true,
   registerValidation = () => ({replace: () => {}, unregister: () => {}}),
-  applyValidationToTreeAtPath = (path, formState) => formState,
-  applyValidationAtPath = (path, formState) => formState,
+  updateTreeAtPath = (path, formState) => formState,
+  updateNodeAtPath = (path, formState) => formState,
 }: Props = {}) {
   return (
     <FormContext.Provider
@@ -25,8 +25,8 @@ export default function TestForm({
         pristine,
         submitted,
         registerValidation,
-        applyValidationToTreeAtPath,
-        applyValidationAtPath,
+        updateTreeAtPath,
+        updateNodeAtPath,
       }}
     >
       {children}

--- a/src/test/tools.js
+++ b/src/test/tools.js
@@ -18,7 +18,7 @@ export function mockFormState<T>(value: T): FormState<T> {
 export function expectLink(link: any) {
   expect(link).toEqual(
     expect.objectContaining({
-      // TODO(dmnd): Find an issue for this bullshit
+      // TODO(dmnd): Would be nice if we could do something like
       // path: expect.arrayContaining(
       //   expect.objectContaining({
       //     type: expect.stringMatching(/(object)|(array)/),
@@ -28,10 +28,9 @@ export function expectLink(link: any) {
       formState: expect.anything(),
       onChange: expect.any(Function),
       onBlur: expect.any(Function),
-      onValidation: expect.any(Function),
     })
   );
-  expect(Object.keys(link).length).toBe(5);
+  expect(Object.keys(link).length).toBe(4);
 }
 
 export function mockLink<T>(formState: FormState<T>): FieldLink<T> {
@@ -40,6 +39,5 @@ export function mockLink<T>(formState: FormState<T>): FieldLink<T> {
     formState,
     onChange: jest.fn(),
     onBlur: jest.fn(),
-    onValidation: jest.fn(),
   };
 }

--- a/src/test/tools.js
+++ b/src/test/tools.js
@@ -18,17 +18,25 @@ export function mockFormState<T>(value: T): FormState<T> {
 export function expectLink(link: any) {
   expect(link).toEqual(
     expect.objectContaining({
+      // TODO(dmnd): Find an issue for this bullshit
+      // path: expect.arrayContaining(
+      //   expect.objectContaining({
+      //     type: expect.stringMatching(/(object)|(array)/),
+      //   })
+      // ),
+      path: expect.anything(),
       formState: expect.anything(),
       onChange: expect.any(Function),
       onBlur: expect.any(Function),
       onValidation: expect.any(Function),
     })
   );
-  expect(Object.keys(link).length).toBe(4);
+  expect(Object.keys(link).length).toBe(5);
 }
 
 export function mockLink<T>(formState: FormState<T>): FieldLink<T> {
   return {
+    path: [],
     formState,
     onChange: jest.fn(),
     onBlur: jest.fn(),

--- a/src/testutils/LinkTap.js
+++ b/src/testutils/LinkTap.js
@@ -2,15 +2,14 @@
 
 import * as React from "react";
 
-import type {FieldLink, Extras, ClientErrors} from "../types";
+import type {FieldLink, Extras} from "../types";
 import type {FormState} from "../formState";
-import type {ShapedTree, ShapedPath} from "../shapedTree";
+import type {ShapedTree} from "../shapedTree";
 
 type Props<T> = {|
   +link: FieldLink<T>,
   +onChange?: (value: T, meta: mixed) => void,
   +onBlur?: () => void,
-  +onValidation?: (path: ShapedPath<T>, errors: ClientErrors) => void,
   +children: (link: FieldLink<T>) => React.Node,
 |};
 
@@ -31,16 +30,6 @@ export default class LinkTap<T> extends React.Component<Props<T>> {
     this.props.link.onBlur(newMeta);
   };
 
-  handleValidation: (ShapedPath<T>, ClientErrors) => void = (
-    path: ShapedPath<T>,
-    errors: ClientErrors
-  ) => {
-    if (this.props.onValidation) {
-      this.props.onValidation(path, errors);
-    }
-    this.props.link.onValidation(path, errors);
-  };
-
   render() {
     const {link} = this.props;
     const tappedLink: FieldLink<T> = {
@@ -48,7 +37,6 @@ export default class LinkTap<T> extends React.Component<Props<T>> {
       formState: link.formState,
       onChange: this.handleChange,
       onBlur: this.handleBlur,
-      onValidation: this.handleValidation,
     };
 
     return this.props.children(tappedLink);

--- a/src/testutils/LinkTap.js
+++ b/src/testutils/LinkTap.js
@@ -44,6 +44,7 @@ export default class LinkTap<T> extends React.Component<Props<T>> {
   render() {
     const {link} = this.props;
     const tappedLink: FieldLink<T> = {
+      path: link.path,
       formState: link.formState,
       onChange: this.handleChange,
       onBlur: this.handleBlur,

--- a/src/types.js
+++ b/src/types.js
@@ -59,7 +59,6 @@ export type FieldLink<T> = {|
   +formState: FormState<T>,
   +onChange: OnChange<T>,
   +onBlur: OnBlur<T>,
-  +onValidation: OnValidation<T>,
   +path: Path,
 |};
 

--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,7 @@
 // @flow strict
 
 import type {ShapedTree, ShapedPath} from "./shapedTree";
+import type {Path} from "./tree";
 import {type FormState} from "./formState";
 
 export type ClientErrors = Array<string> | "pending";
@@ -59,6 +60,7 @@ export type FieldLink<T> = {|
   +onChange: OnChange<T>,
   +onBlur: OnBlur<T>,
   +onValidation: OnValidation<T>,
+  +path: Path,
 |};
 
 export type Validation<T> = T => Array<string>;

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -124,3 +124,15 @@ export function unzip<A, B>(
   }
   return ret;
 }
+
+export function equals<E>(a: $ReadOnlyArray<E>, b: $ReadOnlyArray<E>): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
Fixes #7 with a big change to how validation works:

* `Field`s no longer have responsibility for running their own validation functions. Instead, `Form` takes care of this globally.
* Fields register validation functions with the parent `Form` upon mount, update and unmount
* The errors collections stays in sync with `validations` collection after children unmount/mount or changing the `validation` prop
* Generally, `Form` got more complex, and everything else got simpler.

### Test plan
* Jest & Flow, of course
* Manually clicked around [the example repo](https://github.com/flexport/formula-one-example) and found a few bugs (see commits prefixed with 🐛)
* Manually tested all array operations (`addField`, `removeField`, `moveField`, `addFields`, `filterFields`, `modifyFields`)