### PR TITLE
[Flow] Fix types in shapedTree comparison for 0.97.0

### DIFF
--- a/src/shapedTree.js
+++ b/src/shapedTree.js
@@ -163,9 +163,15 @@ export function checkShape<T, Node>(
   }
   if (tree.type === "object") {
     invariant(value instanceof Object, "value isn't an object in checkTree");
-    Object.keys(tree.children).forEach(k => {
-      // $FlowFixMe There is no typed relation between the shape of value and tree.children as of 0.97.0 this is an error
-      checkShape((value: any)[k], tree.children[k]);
+    const valueEntries = Object.entries(value);
+    const childrenKeys = new Set(Object.keys(tree.children));
+    invariant(
+      valueEntries.length === childrenKeys.size,
+      "value doesn't have the right number of keys"
+    );
+    valueEntries.forEach(([key, value]) => {
+      invariant(childrenKeys.has(key));
+      checkShape(value, tree.children[key]);
     });
   }
   // leaves are allowed to stand in for complex types in T

--- a/src/shapedTree.js
+++ b/src/shapedTree.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import {
   type Tree,
@@ -164,6 +164,7 @@ export function checkShape<T, Node>(
   if (tree.type === "object") {
     invariant(value instanceof Object, "value isn't an object in checkTree");
     Object.keys(tree.children).forEach(k => {
+      // $FlowFixMe There is no typed relation between the shape of value and tree.children as of 0.97.0 this is an error
       checkShape((value: any)[k], tree.children[k]);
     });
   }

--- a/src/shapedTree.js
+++ b/src/shapedTree.js
@@ -1,4 +1,4 @@
-// @flow strict
+// @flow
 
 import {
   type Tree,
@@ -164,7 +164,7 @@ export function checkShape<T, Node>(
   if (tree.type === "object") {
     invariant(value instanceof Object, "value isn't an object in checkTree");
     Object.keys(tree.children).forEach(k => {
-      checkShape(value[k], tree.children[k]);
+      checkShape((value: any)[k], tree.children[k]);
     });
   }
   // leaves are allowed to stand in for complex types in T


### PR DESCRIPTION
From a type perspective `value` doesn't have any relation to `tree.children` in this comparison. In `0.97.0` this is now treated as an error, rather than an implicit `any`.