### PR TITLE
🐛 Don't set changed metadata upon Form mount

### DIFF
--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -131,12 +131,13 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     if (customValue) {
       // A custom change occurred, which means the whole array needs to be
       // revalidated.
-      validatedFormState = this.context.updateTreeAtPath(this.props.link.path, [
-        customValue,
-        newFormState[1],
-      ]);
+      const customChangedFormState = [customValue, newFormState[1]];
+      validatedFormState = this.context.applyCustomChangeToTree(
+        this.props.link.path,
+        customChangedFormState
+      );
     } else {
-      validatedFormState = this.context.updateNodeAtPath(
+      validatedFormState = this.context.applyChangeToNode(
         this.props.link.path,
         newFormState
       );
@@ -158,7 +159,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
   };
 
   _validateThenApplyChange = <E>(formState: FormState<Array<E>>) => {
-    const validatedFormState = this.context.updateNodeAtPath(
+    const validatedFormState = this.context.applyChangeToNode(
       this.props.link.path,
       formState
     );

--- a/src/Field.js
+++ b/src/Field.js
@@ -61,7 +61,7 @@ export default class Field<T> extends React.Component<Props<T>> {
       formState: [_, oldTree],
       onChange,
     } = this.props.link;
-    const newFormState = this.context.updateNodeAtPath(path, [
+    const newFormState = this.context.applyChangeToNode(path, [
       newValue,
       oldTree,
     ]);

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -114,12 +114,13 @@ export default class ObjectField<T: {}> extends React.Component<
     if (customValue) {
       // A custom change occurred, which means the whole object needs to be
       // revalidated.
-      validatedFormState = this.context.updateTreeAtPath(this.props.link.path, [
-        customValue,
-        newFormState[1],
-      ]);
+      const customChangedFormState = [customValue, newFormState[1]];
+      validatedFormState = this.context.applyCustomChangeToTree(
+        this.props.link.path,
+        customChangedFormState
+      );
     } else {
-      validatedFormState = this.context.updateNodeAtPath(
+      validatedFormState = this.context.applyChangeToNode(
         this.props.link.path,
         newFormState
       );

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -147,15 +147,15 @@ describe("ArrayField", () => {
       const link = mockLink(formState);
       const renderFn = jest.fn(() => null);
 
-      const updateNodeAtPath = jest.fn((path, formState) => formState);
+      const applyChangeToNode = jest.fn((path, formState) => formState);
 
       TestRenderer.create(
-        <TestForm updateNodeAtPath={updateNodeAtPath}>
+        <TestForm applyChangeToNode={applyChangeToNode}>
           <ArrayField link={link}>{renderFn}</ArrayField>
         </TestForm>
       );
 
-      expect(updateNodeAtPath).toHaveBeenCalledTimes(0);
+      expect(applyChangeToNode).toHaveBeenCalledTimes(0);
       expect(link.onChange).toHaveBeenCalledTimes(0);
 
       // call a child's onChange
@@ -163,8 +163,8 @@ describe("ArrayField", () => {
       const newElementFormState = mockFormState("newTwo");
       arrayLinks[1].onChange(newElementFormState);
 
-      expect(updateNodeAtPath).toHaveBeenCalledTimes(1);
-      expect(updateNodeAtPath).toHaveBeenCalledWith(
+      expect(applyChangeToNode).toHaveBeenCalledTimes(1);
+      expect(applyChangeToNode).toHaveBeenCalledWith(
         [],
         [["one", "newTwo", "three"], expect.anything()]
       );
@@ -240,6 +240,7 @@ describe("ArrayField", () => {
           expect.anything()
         );
       });
+
       it("validates after entry is added", () => {
         const renderFn = jest.fn(() => null);
         const validation = jest.fn(() => ["an error"]);

--- a/src/test/Field.test.js
+++ b/src/test/Field.test.js
@@ -78,22 +78,22 @@ describe("Field", () => {
     const formState = mockFormState("Hello world.");
     const link = mockLink(formState);
 
-    const updateNodeAtPath = jest.fn((path, formState) => formState);
+    const applyChangeToNode = jest.fn((path, formState) => formState);
 
     const renderer = TestRenderer.create(
-      <TestForm updateNodeAtPath={updateNodeAtPath}>
+      <TestForm applyChangeToNode={applyChangeToNode}>
         <TestField link={link} />
       </TestForm>
     );
     const inner = renderer.root.findByType(TestInput);
 
-    expect(updateNodeAtPath).toHaveBeenCalledTimes(0);
+    expect(applyChangeToNode).toHaveBeenCalledTimes(0);
     expect(link.onChange).toHaveBeenCalledTimes(0);
 
     inner.instance.change("You've got mail");
 
-    expect(updateNodeAtPath).toHaveBeenCalledTimes(1);
-    expect(updateNodeAtPath).toHaveBeenCalledWith(
+    expect(applyChangeToNode).toHaveBeenCalledTimes(1);
+    expect(applyChangeToNode).toHaveBeenCalledWith(
       [],
       ["You've got mail", expect.anything()]
     );

--- a/src/test/ObjectField.test.js
+++ b/src/test/ObjectField.test.js
@@ -193,15 +193,15 @@ describe("ObjectField", () => {
       const link = mockLink(formState);
       const renderFn = jest.fn(() => null);
 
-      const updateNodeAtPath = jest.fn((path, formState) => formState);
+      const applyChangeToNode = jest.fn((path, formState) => formState);
 
       TestRenderer.create(
-        <TestForm updateNodeAtPath={updateNodeAtPath}>
+        <TestForm applyChangeToNode={applyChangeToNode}>
           <ObjectField link={link}>{renderFn}</ObjectField>
         </TestForm>
       );
 
-      expect(updateNodeAtPath).toHaveBeenCalledTimes(0);
+      expect(applyChangeToNode).toHaveBeenCalledTimes(0);
       expect(link.onChange).toHaveBeenCalledTimes(0);
 
       // call the child onChange
@@ -209,8 +209,8 @@ describe("ObjectField", () => {
       const newChildMeta = mockFormState("newString");
       objectLinks.string.onChange(newChildMeta);
 
-      expect(updateNodeAtPath).toHaveBeenCalledTimes(1);
-      expect(updateNodeAtPath).toHaveBeenCalledWith(
+      expect(applyChangeToNode).toHaveBeenCalledTimes(1);
+      expect(applyChangeToNode).toHaveBeenCalledWith(
         [],
         [{string: "newString", number: 42}, expect.anything()]
       );

--- a/src/test/TestForm.js
+++ b/src/test/TestForm.js
@@ -15,8 +15,8 @@ export default function TestForm({
   pristine = false,
   submitted = true,
   registerValidation = () => ({replace: () => {}, unregister: () => {}}),
-  updateTreeAtPath = (path, formState) => formState,
-  updateNodeAtPath = (path, formState) => formState,
+  applyCustomChangeToTree = (path, formState) => formState,
+  applyChangeToNode = (path, formState) => formState,
 }: Props = {}) {
   return (
     <FormContext.Provider
@@ -25,8 +25,8 @@ export default function TestForm({
         pristine,
         submitted,
         registerValidation,
-        updateTreeAtPath,
-        updateNodeAtPath,
+        applyCustomChangeToTree,
+        applyChangeToNode,
       }}
     >
       {children}


### PR DESCRIPTION
Some important behaviour regressed with the new validation path when
`Form` mounts. `changed` & `touched` metadata definitely shouldn't be
set at this time, because the user hasn't touched anything.

Also add assertions to an existing test that show that `Fields` mounted
after the `Form` don't incorrectly set touched metadata.

Because setting changed metadata got moved out from `updateTreeAtPath`,
I renamed these context functions _again_ for clarity...

* s/updateTreeAtPath/applyCustomChangeToTree/g
* s/updateNodeAtPath/applyChangeToNode/g

@flex-tjon I think this fixes the bug [you ran into](https://github.com/flexport/flexport/pull/42191#discussion_r280884542).

#### Test plan
Added new tests. Also tested in the browser with the example app.