### PR TITLE
Improve FormContext types

### DIFF
--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -27,7 +27,12 @@ import {
   zip,
   unzip,
 } from "./utils/array";
-import {FormContext, type ValidationOps, validationFnNoOps} from "./Form";
+import {
+  FormContext,
+  type FormContextPayload,
+  type ValidationOps,
+  validationFnNoOps,
+} from "./Form";
 import {
   type FormState,
   replaceArrayChild,
@@ -91,6 +96,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     validation: () => [],
   };
   static contextType = FormContext;
+  context: FormContextPayload<Array<E>>;
 
   validationFnOps: ValidationOps<Array<E>> = validationFnNoOps();
 
@@ -158,13 +164,13 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     );
   };
 
-  _validateThenApplyChange = <E>(formState: FormState<Array<E>>) => {
+  _validateThenApplyChange(formState: FormState<Array<E>>) {
     const validatedFormState = this.context.applyChangeToNode(
       this.props.link.path,
       formState
     );
     this.props.link.onChange(validatedFormState);
-  };
+  }
 
   _addChildField: (number, E) => void = (index: number, childValue: E) => {
     const [oldValue, oldTree] = this.props.link.formState;
@@ -182,6 +188,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
       ),
       oldTree
     );
+
     this._validateThenApplyChange([newValue, newTree]);
   };
 

--- a/src/Field.js
+++ b/src/Field.js
@@ -3,7 +3,12 @@
 import * as React from "react";
 import type {FieldLink, Validation, Err, AdditionalRenderInfo} from "./types";
 import {mapRoot} from "./shapedTree";
-import {FormContext, type ValidationOps, validationFnNoOps} from "./Form";
+import {
+  FormContext,
+  type FormContextPayload,
+  type ValidationOps,
+  validationFnNoOps,
+} from "./Form";
 import {setExtrasTouched, getExtras, isValid} from "./formState";
 
 type Props<T> = {|
@@ -34,6 +39,7 @@ export default class Field<T> extends React.Component<Props<T>> {
     validation: () => [],
   };
   static contextType = FormContext;
+  context: FormContextPayload<T>;
 
   validationFnOps: ValidationOps<T> = validationFnNoOps();
 

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -9,7 +9,12 @@ import type {
   AdditionalRenderInfo,
   CustomChange,
 } from "./types";
-import {FormContext, type ValidationOps, validationFnNoOps} from "./Form";
+import {
+  FormContext,
+  type FormContextPayload,
+  type ValidationOps,
+  validationFnNoOps,
+} from "./Form";
 import {
   type FormState,
   replaceObjectChild,
@@ -70,6 +75,7 @@ export default class ObjectField<T: {}> extends React.Component<
   void
 > {
   static contextType = FormContext;
+  context: FormContextPayload<T>;
   static _contextType = FormContext;
   static defaultProps = {
     validation: () => [],

--- a/src/test/TestForm.js
+++ b/src/test/TestForm.js
@@ -5,7 +5,7 @@ import * as React from "react";
 import {FormContext, type FormContextPayload} from "../Form";
 
 type Props = {
-  ...$Shape<{...FormContextPayload}>,
+  ...$Shape<{...FormContextPayload<mixed>}>,
   children: React.Node,
 };
 


### PR DESCRIPTION
In https://github.com/flexport/formula-one/pull/38 I didn't notice that
Flow doesn't understand `contextType`, so `this.context` becomes 
uncovered.

According to https://github.com/facebook/flow/issues/7166 this isn't 
going to be fixed, but there's a simple workaround (if you remember to 
apply it, at least.)

So apply it here and improves types to avoid all ensuing errors.

One interesting thing that happens here is that more specific types are 
declared in fields than that exists in provider Form. This keeps fields
behaving properly but requires casts in Form. Better ideas are welcome!

#### Test plan
`yarn flow`