### PR TITLE
Use $ReadOnlyArray<string> for validation errors

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -78,7 +78,7 @@ export const FormContext: React.Context<
 });
 
 function applyExternalErrorsToFormState<T>(
-  externalErrors: null | {[path: string]: Array<string>},
+  externalErrors: null | {[path: string]: $ReadOnlyArray<string>},
   formState: FormState<T>
 ): FormState<T> {
   const [value, oldTree] = formState;
@@ -94,7 +94,7 @@ function applyExternalErrorsToFormState<T>(
       oldTree
     );
     Object.keys(externalErrors).forEach(key => {
-      const newErrors: Array<string> = externalErrors[key];
+      const newErrors = externalErrors[key];
       const path = shapePath(value, pathFromPathString(key));
 
       if (path != null) {
@@ -311,7 +311,7 @@ type Props<T, ExtraSubmitData> = {|
   +onSubmit: (T, ExtraSubmitData) => void,
   +onChange: T => void,
   +onValidation: boolean => void,
-  +externalErrors: null | {[path: string]: Array<string>},
+  +externalErrors: null | {[path: string]: $ReadOnlyArray<string>},
   +children: (
     link: FieldLink<T>,
     onSubmit: (ExtraSubmitData) => void,
@@ -322,7 +322,7 @@ type State<T> = {
   formState: FormState<T>,
   pristine: boolean,
   submitted: boolean,
-  oldExternalErrors: null | {[path: string]: Array<string>},
+  oldExternalErrors: null | {[path: string]: $ReadOnlyArray<string>},
 };
 export default class Form<T, ExtraSubmitData> extends React.Component<
   Props<T, ExtraSubmitData>,

--- a/src/types.js
+++ b/src/types.js
@@ -5,7 +5,7 @@ import type {Path} from "./tree";
 import {type FormState} from "./formState";
 
 export type ClientErrors = Array<string> | "pending";
-export type ExternalErrors = Array<string> | "unchecked";
+export type ExternalErrors = $ReadOnlyArray<string> | "unchecked";
 export type Err = {
   client: ClientErrors,
   external: ExternalErrors,


### PR DESCRIPTION
As requested by @flex-tjon [here][1]. Don't know why we weren't already 
doing this.

Also I had to edit a lot of places, so maybe there's opportunity for a type
alias, but that can be solved another day.

  [1]: https://github.com/flexport/flexport/pull/44287#discussion_r292715411