### PR TITLE
🐛 Avoid crash when formstate objects change shape

### DIFF
--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -43,6 +43,7 @@ import {
   isValid,
 } from "./formState";
 import type {Path} from "./tree";
+import alwaysValid from "./alwaysValid";
 
 type ToFieldLink = <T>(T) => FieldLink<T>;
 type Links<E> = Array<$Call<ToFieldLink, E>>;
@@ -93,7 +94,7 @@ function makeLinks<E>(
 
 export default class ArrayField<E> extends React.Component<Props<E>, void> {
   static defaultProps = {
-    validation: () => [],
+    validation: alwaysValid,
   };
   static contextType = FormContext;
   context: FormContextPayload<Array<E>>;
@@ -107,10 +108,8 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     );
   }
 
-  componentDidUpdate(prevProps: Props<E>) {
-    if (prevProps.validation !== this.props.validation) {
-      this.validationFnOps.replace(this.props.validation);
-    }
+  componentDidUpdate() {
+    this.validationFnOps.replace(this.props.validation);
   }
 
   componentWillUnmount() {

--- a/src/Field.js
+++ b/src/Field.js
@@ -10,6 +10,7 @@ import {
   validationFnNoOps,
 } from "./Form";
 import {setExtrasTouched, getExtras, isValid} from "./formState";
+import alwaysValid from "./alwaysValid";
 
 type Props<T> = {|
   +link: FieldLink<T>,
@@ -36,7 +37,7 @@ function getErrors(errors: Err) {
 
 export default class Field<T> extends React.Component<Props<T>> {
   static defaultProps = {
-    validation: () => [],
+    validation: alwaysValid,
   };
   static contextType = FormContext;
   context: FormContextPayload<T>;
@@ -50,10 +51,8 @@ export default class Field<T> extends React.Component<Props<T>> {
     );
   }
 
-  componentDidUpdate(prevProps: Props<T>) {
-    if (prevProps.validation !== this.props.validation) {
-      this.validationFnOps.replace(this.props.validation);
-    }
+  componentDidUpdate() {
+    this.validationFnOps.replace(this.props.validation);
   }
 
   componentWillUnmount() {

--- a/src/Form.js
+++ b/src/Form.js
@@ -371,7 +371,7 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
 
   validations: ValidationMap;
   initialValidationComplete = false;
-  pathForPostCommitValidation: null | Path = null;
+  pendingValidationPath: null | Path = null;
 
   constructor(props: Props<T, ExtraSubmitData>) {
     super(props);
@@ -427,9 +427,9 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
     newState: FormState<T>
   ) => {
     this.setState({formState: newState, pristine: false}, () => {
-      if (this.pathForPostCommitValidation !== null) {
-        this.recomputeErrorsAtPathAndRender(this.pathForPostCommitValidation);
-        this.pathForPostCommitValidation = null;
+      if (this.pendingValidationPath !== null) {
+        this.recomputeErrorsAtPathAndRender(this.pendingValidationPath);
+        this.pendingValidationPath = null;
       }
     });
     this.props.onChange(newState[0]);
@@ -438,7 +438,7 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
     //   correspond directly to the internal onValidation. Internally
     //   onValidation means (on initial validation). Externally, it means
     //   on any validation.
-    if (this.pathForPostCommitValidation === null) {
+    if (this.pendingValidationPath === null) {
       this.props.onValidation(isValid(newState));
     }
   };
@@ -582,10 +582,10 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
               this.validations
             );
             invariant(
-              this.pathForPostCommitValidation === null,
+              this.pendingValidationPath === null,
               "Unexpected pending validation. This is a bug in Formula One, please report it."
             );
-            this.pathForPostCommitValidation = path;
+            this.pendingValidationPath = path;
             return changedFormState(value);
           },
           applyChangeToNode: (path, formState) =>

--- a/src/Form.js
+++ b/src/Form.js
@@ -433,11 +433,6 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
       }
     });
     this.props.onChange(newState[0]);
-    // TODO(zach): This is a bit gross, but the general purpose here is
-    //   that onValidation outside the form (in the public API) doesn't
-    //   correspond directly to the internal onValidation. Internally
-    //   onValidation means (on initial validation). Externally, it means
-    //   on any validation.
     if (this.pendingValidationPath === null) {
       this.props.onValidation(isValid(newState));
     }

--- a/src/Form.js
+++ b/src/Form.js
@@ -243,7 +243,7 @@ function validateTree<T>(
  * Note this does not remove validation functions at prefix itself. Only child
  * paths are removed.
  */
-function removeChildValidationsAtPath(
+function removeDescendantValidations(
   prefix: Path,
   validations: ValidationMap
 ): ValidationMap {
@@ -582,7 +582,7 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
           shouldShowError: this.props.feedbackStrategy.bind(null, metaForm),
           registerValidation: this.handleRegisterValidation,
           applyCustomChangeToTree: (path, [value, _tree]) => {
-            this.validations = removeChildValidationsAtPath(
+            this.validations = removeDescendantValidations(
               path,
               this.validations
             );

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -30,6 +30,7 @@ import {
   dangerouslyReplaceObjectChild,
 } from "./shapedTree";
 import type {Path} from "./tree";
+import alwaysValid from "./alwaysValid";
 
 type ToFieldLink = <T>(T) => FieldLink<T>;
 type Links<T: {}> = $ObjMap<T, ToFieldLink>;
@@ -78,7 +79,7 @@ export default class ObjectField<T: {}> extends React.Component<
   context: FormContextPayload<T>;
   static _contextType = FormContext;
   static defaultProps = {
-    validation: () => [],
+    validation: alwaysValid,
   };
 
   validationFnOps: ValidationOps<T> = validationFnNoOps();
@@ -90,10 +91,8 @@ export default class ObjectField<T: {}> extends React.Component<
     );
   }
 
-  componentDidUpdate(prevProps: Props<T>) {
-    if (prevProps.validation !== this.props.validation) {
-      this.validationFnOps.replace(this.props.validation);
-    }
+  componentDidUpdate() {
+    this.validationFnOps.replace(this.props.validation);
   }
 
   componentWillUnmount() {

--- a/src/alwaysValid.js
+++ b/src/alwaysValid.js
@@ -1,0 +1,5 @@
+// @flow strict
+
+export default function alwaysValid<T>(_x: T) {
+  return [];
+}

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -625,12 +625,12 @@ describe("ArrayField", () => {
       const inner = renderer.root.findAllByType(TestInput)[0];
       inner.instance.change("zach");
 
-      // Validate the whole subtree due to the customChange child validates
-      // once. Note that child validation will be called 3 times. Once after the
-      // change, then twice more after the customChange triggers a validation fo
-      // the entire subtree.
+      // Note that child validation will be called 5 times:
+      // * Once in response to the change
+      // * Twice more from the arrayEquals test in replaceValidation
+      // * Twice more from recomputeErrorsAtPathAndRender
       expect(parentValidation).toHaveBeenCalledTimes(1);
-      expect(childValidation).toHaveBeenCalledTimes(1 + 2);
+      expect(childValidation).toHaveBeenCalledTimes(1 + 2 + 2);
 
       const link = renderer.root.findByType(ArrayField).instance.props.link;
       expect(link.formState).toEqual([["1", "2"], expect.anything()]);

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -662,5 +662,33 @@ describe("ArrayField", () => {
       // self-referential and thus not printable
       expect(Object.is(testInstance, nextTestInstance)).toBe(true);
     });
+
+    describe("length", () => {
+      function expectLengthChangeToNotThrow(from, to) {
+        const renderer = TestRenderer.create(
+          <Form initialValue={from}>
+            {link => (
+              <ArrayField link={link} customChange={() => to}>
+                {links =>
+                  links.map((link, i) => <TestField link={link} key={i} />)
+                }
+              </ArrayField>
+            )}
+          </Form>
+        );
+        const inner = renderer.root.findAllByType(TestInput)[0];
+        expect(() => {
+          inner.instance.change("z");
+        }).not.toThrow();
+      }
+
+      it("length can increase", () => {
+        expectLengthChangeToNotThrow(["a"], ["a", "b", "c"]);
+      });
+
+      it("length can decrease", () => {
+        expectLengthChangeToNotThrow(["a", "b", "c"], ["a"]);
+      });
+    });
   });
 });

--- a/src/test/ObjectField.test.js
+++ b/src/test/ObjectField.test.js
@@ -543,34 +543,23 @@ describe("ObjectField", () => {
     });
 
     it("doesn't crash when object changes shape", () => {
-      type Union = {|tag: "a", a: string|} | {|tag: "b", b: string|};
-      const initialValue: Union = {tag: "a", a: "a"};
+      type Union = {|a: string|} | {|b: string|};
+      const initialValue: Union = {a: "a"};
 
-      function customChange(
-        prevValue: Union,
-        nextValue: {tag: "a"} | {tag: "b"}
-      ): null | Union {
-        if (prevValue.tag !== "a" && nextValue.tag === "a") {
-          return {tag: "a", a: ""};
-        } else if (prevValue.tag !== "b" && nextValue.tag === "b") {
-          return {tag: "b", b: ""};
-        }
-        return null;
+      function customChange(): null | Union {
+        return {b: ""};
       }
 
       function App() {
         return (
           <Form initialValue={initialValue}>
-            {(link, _onSubmit, {value}) => (
+            {link => (
               <ObjectField link={link} customChange={customChange}>
                 {link => (
                   <>
-                    <TestField link={link.tag} />
-                    {value.tag === "a" ? (
-                      // $FlowFixMe(dmnd)
+                    {link.a ? (
                       <TestField link={link.a} />
                     ) : (
-                      // $FlowFixMe(dmnd)
                       <TestField link={link.b} />
                     )}
                   </>

--- a/src/test/ObjectField.test.js
+++ b/src/test/ObjectField.test.js
@@ -542,38 +542,27 @@ describe("ObjectField", () => {
       ]);
     });
 
-    it("doesn't crash when object changes shape", () => {
-      type Union = {|a: string|} | {|b: string|};
-      const initialValue: Union = {a: "a"};
-
-      function customChange(): null | Union {
-        return {b: ""};
-      }
-
-      function App() {
-        return (
-          <Form initialValue={initialValue}>
-            {link => (
-              <ObjectField link={link} customChange={customChange}>
-                {link => (
-                  <>
-                    {link.a ? (
-                      <TestField link={link.a} />
-                    ) : (
-                      <TestField link={link.b} />
-                    )}
-                  </>
-                )}
-              </ObjectField>
-            )}
-          </Form>
-        );
-      }
-
-      const renderer = TestRenderer.create(<App />);
+    it("can change shape", () => {
+      const renderer = TestRenderer.create(
+        <Form initialValue={{a: "a"}}>
+          {link => (
+            <ObjectField link={link} customChange={() => ({b: "b"})}>
+              {link => (
+                <>
+                  {link.a ? (
+                    <TestField link={link.a} />
+                  ) : (
+                    <TestField link={link.b} />
+                  )}
+                </>
+              )}
+            </ObjectField>
+          )}
+        </Form>
+      );
       const inner = renderer.root.findAllByType(TestInput)[0];
       expect(() => {
-        inner.instance.change("b");
+        inner.instance.change("z");
       }).not.toThrow();
     });
   });

--- a/src/test/TestField.js
+++ b/src/test/TestField.js
@@ -3,6 +3,7 @@
 import * as React from "react";
 import type {FieldLink, Validation} from "../types";
 import Field from "../Field";
+import alwaysValid from "../alwaysValid";
 
 export class TestInput extends React.Component<{|
   value: string,
@@ -29,7 +30,7 @@ type Props = {|
 
 export default class TestField extends React.Component<Props> {
   static defaultProps = {
-    validation: () => [],
+    validation: alwaysValid,
   };
 
   render() {


### PR DESCRIPTION
A crash was reported where a formstate object changes shape after a
`customChange`. The new shape was being validated by a collection of
validation functions arranged in the previous object shape, causing all
sorts of mayhem.

To avoid this, remove all validation functions after `customChange`,
then render, causing new validation functions to be added again (in the
correct shape). Only after the new shape has been built up does
validation run.

Test plan:

* @larajanecka & I verified the steps that crashed bid app before this change are now working.
* The new tests crash prior to the changes made in this PR:

  ```bash
  git checkout origin/master
  git checkout custom-change-validation-fn-rebuild -- src/test/ArrayField.test.js src/test/ObjectField.test.js
  yarn test
  ```