### PR TITLE
Add CircleCI integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:10.16
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: yarn test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/aflexport/formula-one.svg?style=svg)](https://circleci.com/gh/aflexport/formula-one)
+
 # formula-one
 
 **formula-one** is a library which makes it easier to write type-safe forms with validations and complex inputs.


### PR DESCRIPTION
Looks like the repo admin has to do the first build on CircleCI. Then other members in the org will get access to change the build process. For now. the badge below is linked to my fork.
```markdown
[![CircleCI](https://circleci.com/gh/aflexport/formula-one.svg?style=svg)](https://circleci.com/gh/aflexport/formula-one)
```