### PR TITLE
Refactor internal classes to hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.9.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
@@ -41,7 +41,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "@types/react": "^16.8.23",
+    "@types/react": "^16.9.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10",
     "babel-jest": "^24",
@@ -57,7 +57,7 @@
     "jest": "^24.5.0",
     "lint-staged": "^7.2.0",
     "prettier": "^1.14.0",
-    "react": "^16.5.2",
-    "react-test-renderer": "^16.5.2"
+    "react": "^16.9.0",
+    "react-test-renderer": "^16.9.0"
   }
 }

--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -307,7 +307,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
       this._handleChildBlur
     );
     return (
-      <React.Fragment>
+      <>
         {this.props.children(
           links,
           {
@@ -328,7 +328,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
             value: formState[0],
           }
         )}
-      </React.Fragment>
+      </>
     );
   }
 }

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -157,7 +157,7 @@ export default class ObjectField<T: {}> extends React.Component<
       this._handleChildBlur
     );
     return (
-      <React.Fragment>
+      <>
         {this.props.children(links, {
           touched: getExtras(formState).meta.touched,
           changed: getExtras(formState).meta.changed,
@@ -167,7 +167,7 @@ export default class ObjectField<T: {}> extends React.Component<
           valid: isValid(formState),
           value: formState[0],
         })}
-      </React.Fragment>
+      </>
     );
   }
 }

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -600,7 +600,7 @@ describe("ArrayField", () => {
               validation={parentValidation}
             >
               {links => (
-                <React.Fragment>
+                <>
                   {links.map((link, i) => (
                     <TestField
                       key={i}
@@ -608,7 +608,7 @@ describe("ArrayField", () => {
                       validation={childValidation}
                     />
                   ))}
-                </React.Fragment>
+                </>
               )}
             </ArrayField>
           )}

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -572,7 +572,7 @@ describe("ArrayField", () => {
       expect(customChange).toHaveBeenCalledTimes(1);
 
       // onChange should be called with the result of customChange
-      const link = renderer.root.findByType(ArrayField).instance.props.link;
+      const link = renderer.root.findByType(ArrayField).props.link;
       expect(link.formState).toEqual([
         ["one", "zwei", "three"],
         expect.anything(),
@@ -632,7 +632,7 @@ describe("ArrayField", () => {
       expect(parentValidation).toHaveBeenCalledTimes(1);
       expect(childValidation).toHaveBeenCalledTimes(1 + 2 + 2);
 
-      const link = renderer.root.findByType(ArrayField).instance.props.link;
+      const link = renderer.root.findByType(ArrayField).props.link;
       expect(link.formState).toEqual([["1", "2"], expect.anything()]);
     });
 

--- a/src/test/Form.test.js
+++ b/src/test/Form.test.js
@@ -477,7 +477,7 @@ describe("Form", () => {
           {link => (
             <ObjectField link={link} validation={() => ["Toplevel error"]}>
               {link => (
-                <React.Fragment>
+                <>
                   <TestField
                     link={link.errors}
                     validation={() => ["Two", "errors"]}
@@ -501,7 +501,7 @@ describe("Form", () => {
                       ))
                     }
                   </ArrayField>
-                </React.Fragment>
+                </>
               )}
             </ObjectField>
           )}
@@ -542,7 +542,7 @@ describe("Form", () => {
           {link => (
             <ObjectField link={link} validation={() => ["Toplevel error"]}>
               {link => (
-                <React.Fragment>
+                <>
                   <NaughtyRenderingField
                     link={link.naughty}
                     validation={() => ["Naughty", "errors"]}
@@ -551,7 +551,7 @@ describe("Form", () => {
                     link={link.nice}
                     validation={() => ["Nice", "errors"]}
                   />
-                </React.Fragment>
+                </>
               )}
             </ObjectField>
           )}

--- a/src/test/Form.test.js
+++ b/src/test/Form.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from "react";
+import React, {useLayoutEffect} from "react";
 import TestRenderer from "react-test-renderer";
 import FeedbackStrategies from "../feedbackStrategies";
 import Form, {FormContext} from "../Form";
@@ -14,19 +14,21 @@ import TestField, {TestInput} from "./TestField";
 import LinkTap from "../testutils/LinkTap";
 import {forgetShape} from "../shapedTree";
 
-class NaughtyRenderingInput extends React.Component<{|
+type NaughtyProps = {|
   value: string,
   errors: $ReadOnlyArray<string>,
   onChange: string => void,
   onBlur: () => void,
-|}> {
-  componentDidMount() {
-    this.props.onChange("hello from cDM()");
-  }
-  render() {
-    return null;
-  }
+|}
+
+const NaughtyRenderingInput = (props: NaughtyProps) => {
+  // identical to useEffect, but it fires synchronously
+  useLayoutEffect(() => {
+    props.onChange("hello from cDM()");
+  }, []);
+  return null;
 }
+
 function NaughtyRenderingField(props) {
   return (
     <Field {...props}>
@@ -132,7 +134,7 @@ describe("Form", () => {
         </Form>
       );
 
-      const formState = renderer.root.findByType(ObjectField).instance.props
+      const formState = renderer.root.findByType(ObjectField).props
         .link.formState;
 
       let node = formState[1];
@@ -181,7 +183,7 @@ describe("Form", () => {
         </Form>
       );
 
-      const formState = renderer.root.findByType(ObjectField).instance.props
+      const formState = renderer.root.findByType(ObjectField).props
         .link.formState;
 
       let node = formState[1];
@@ -303,7 +305,7 @@ describe("Form", () => {
         </Form>
       );
 
-      let link = renderer.root.findAllByType(TestField)[0].instance.props.link;
+      let link = renderer.root.findAllByType(TestField)[0].props.link;
       let errors = link.formState[1].data.errors.client;
       expect(errors).toEqual(["error 1"]);
 
@@ -313,7 +315,7 @@ describe("Form", () => {
         </Form>
       );
 
-      link = renderer.root.findAllByType(TestField)[0].instance.props.link;
+      link = renderer.root.findAllByType(TestField)[0].props.link;
       errors = link.formState[1].data.errors.client;
       expect(errors).toEqual(["error 2"]);
     });
@@ -761,7 +763,7 @@ describe("Form", () => {
       expect(validation1).toHaveBeenCalledTimes(1);
       expect(validation2).toHaveBeenCalledTimes(1);
 
-      let rootFormState = renderer.root.findByType(TestForm).instance.props.link
+      let rootFormState = renderer.root.findByType(TestForm).props.link
         .formState[1];
 
       let string1Errors = rootFormState.children.string1.data.errors.client;
@@ -786,7 +788,7 @@ describe("Form", () => {
       expect(validation1).toHaveBeenCalledTimes(1);
       expect(validation2).toHaveBeenCalledTimes(1);
 
-      rootFormState = renderer.root.findByType(TestForm).instance.props.link
+      rootFormState = renderer.root.findByType(TestForm).props.link
         .formState[1];
 
       // error for string1 remains
@@ -843,8 +845,7 @@ describe("Form", () => {
           )}
         </Form>
       );
-
-      let link = renderer.root.findAllByType(TestField)[0].instance.props.link;
+      let link = renderer.root.findAllByType(TestField)[0].props.link;
       let errors = link.formState[1].data.errors.client;
       expect(errors).toEqual(["error 1", "error 2"]);
 
@@ -858,7 +859,7 @@ describe("Form", () => {
         </Form>
       );
 
-      link = renderer.root.findAllByType(TestField)[0].instance.props.link;
+      link = renderer.root.findAllByType(TestField)[0].props.link;
       errors = link.formState[1].data.errors.client;
       expect(errors).toEqual(["error 1"]);
     });

--- a/src/test/ObjectField.test.js
+++ b/src/test/ObjectField.test.js
@@ -369,7 +369,7 @@ describe("ObjectField", () => {
 
       expect(customChange).toHaveBeenCalledTimes(1);
 
-      const link = renderer.root.findByType(ObjectField).instance.props.link;
+      const link = renderer.root.findByType(ObjectField).props.link;
       // the value we get out is as if customChange didn't exist
       expect(link.formState).toEqual([
         {
@@ -442,7 +442,7 @@ describe("ObjectField", () => {
       expect(parentValidation).toHaveBeenCalledTimes(1);
       expect(childValidation).toHaveBeenCalledTimes(1 + 2 + 2);
 
-      const link = renderer.root.findByType(ObjectField).instance.props.link;
+      const link = renderer.root.findByType(ObjectField).props.link;
       expect(link.formState).toEqual([
         {
           string: "a whole new value",

--- a/src/test/ObjectField.test.js
+++ b/src/test/ObjectField.test.js
@@ -412,13 +412,13 @@ describe("ObjectField", () => {
               validation={parentValidation}
             >
               {links => (
-                <React.Fragment>
+                <>
                   <TestField link={links.string} validation={childValidation} />
                   <TestField
                     link={links.string2}
                     validation={childValidation}
                   />
-                </React.Fragment>
+                </>
               )}
             </ObjectField>
           )}

--- a/src/test/TestField.js
+++ b/src/test/TestField.js
@@ -25,12 +25,14 @@ export class TestInput extends React.Component<{|
 
 type Props = {|
   link: FieldLink<string>,
-  validation: Validation<string>,
+  validation?: Validation<string>,
 |};
 
 const TestField = (props: Props) => {
+  const validation = props.validation || alwaysValid;
+
   return (
-    <Field link={props.link} validation={props.validation}>
+    <Field link={props.link} validation={validation}>
       {(value, errors, onChange, onBlur) => (
         <TestInput
           value={value}
@@ -42,9 +44,5 @@ const TestField = (props: Props) => {
     </Field>
   )
 }
-
-TestField.defaultProps = {
-  validation: alwaysValid
-};
 
 export default TestField;

--- a/src/test/TestField.js
+++ b/src/test/TestField.js
@@ -28,23 +28,23 @@ type Props = {|
   validation: Validation<string>,
 |};
 
-export default class TestField extends React.Component<Props> {
-  static defaultProps = {
-    validation: alwaysValid,
-  };
-
-  render() {
-    return (
-      <Field link={this.props.link} validation={this.props.validation}>
-        {(value, errors, onChange, onBlur) => (
-          <TestInput
-            value={value}
-            errors={errors}
-            onChange={onChange}
-            onBlur={onBlur}
-          />
-        )}
-      </Field>
-    );
-  }
+const TestField = (props: Props) => {
+  return (
+    <Field link={props.link} validation={props.validation}>
+      {(value, errors, onChange, onBlur) => (
+        <TestInput
+          value={value}
+          errors={errors}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+      )}
+    </Field>
+  )
 }
+
+TestField.defaultProps = {
+  validation: alwaysValid
+};
+
+export default TestField;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1179,10 +1179,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
   integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
 
-"@types/react@^16.8.23":
-  version "16.8.23"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.23.tgz#ec6be3ceed6353a20948169b6cb4c97b65b97ad2"
-  integrity sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==
+"@types/react@^16.9.0":
+  version "16.9.1"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.1.tgz#862c83b4c9d5cd116e42fd9a4f3694843cd2c051"
+  integrity sha512-jGM2x8F7m7/r+81N/BOaUKVwbC5Cdw6ExlWEUpr77XPwVeNvAppnPEnMMLMfxRDYL8FPEX8MHjwtD2NQMJ0yyQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -5193,7 +5193,7 @@ react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.5.tgz#c54ac229dd66b5afe0de5acbe47647c3da692ff8"
   integrity sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==
 
-react-test-renderer@^16.5.2:
+react-test-renderer@^16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.9.0.tgz#7ed657a374af47af88f66f33a3ef99c9610c8ae9"
   integrity sha512-R62stB73qZyhrJo7wmCW9jgl/07ai+YzvouvCXIJLBkRlRqLx4j9RqcLEAfNfU3OxTGucqR2Whmn3/Aad6L3hQ==
@@ -5203,7 +5203,7 @@ react-test-renderer@^16.5.2:
     react-is "^16.9.0"
     scheduler "^0.15.0"
 
-react@^16.5.2:
+react@^16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
   integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4315,7 +4315,7 @@ log-update@^1.0.2:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5132,12 +5132,13 @@ prompts@^2.0.1:
     sisteransi "^1.0.0"
 
 prop-types@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
-  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
   dependencies:
-    loose-envify "^1.3.1"
+    loose-envify "^1.4.0"
     object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -5182,10 +5183,10 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-is@^16.6.1:
-  version "16.6.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.1.tgz#f77b1c3d901be300abe8d58645b7a59e794e5982"
-  integrity sha512-wOKsGtvTMYs7WAscmwwdM8sfRRvE17Ym30zFj3n37Qx5tHRfhenPKEPILHaHob6WoLFADmQm1ZNrE5xMCM6sCw==
+react-is@^16.8.1, react-is@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
 react-is@^16.8.4:
   version "16.8.5"
@@ -5193,24 +5194,23 @@ react-is@^16.8.4:
   integrity sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==
 
 react-test-renderer@^16.5.2:
-  version "16.6.1"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.6.1.tgz#8ea357652be3cf81cbd6b2f686e74ebe67c17b78"
-  integrity sha512-sgZwJZYIgQptRi2qk5+gB8FBQGk4gLSs0gmKZPMfhd3dLkdxIUwVLHteLN3Bnj4LokIZd3U+V2NEJUqeV2PT2w==
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.9.0.tgz#7ed657a374af47af88f66f33a3ef99c9610c8ae9"
+  integrity sha512-R62stB73qZyhrJo7wmCW9jgl/07ai+YzvouvCXIJLBkRlRqLx4j9RqcLEAfNfU3OxTGucqR2Whmn3/Aad6L3hQ==
   dependencies:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    react-is "^16.6.1"
-    scheduler "^0.11.0"
+    react-is "^16.9.0"
+    scheduler "^0.15.0"
 
 react@^16.5.2:
-  version "16.6.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.6.1.tgz#ee2aef4f0a09e494594882029821049772f915fe"
-  integrity sha512-OtawJThYlvRgm9BXK+xTL7BIlDx8vv21j+fbQDjRRUyok6y7NyjlweGorielTahLZHYIdKUoK2Dp9ByVWuMqxw==
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
+  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.11.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -5576,10 +5576,10 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.0.tgz#def1f1bfa6550cc57981a87106e65e8aea41a6b5"
-  integrity sha512-MAYbBfmiEHxF0W+c4CxMpEqMYK+rYF584VP/qMKSiHM6lTkBKKYOJaDiSILpJHla6hBOsVd6GucPL46o2Uq3sg==
+scheduler@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
+  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
- Upgrade react and react-test-renderer for hooks usages
- refactor some lightweight react classes to function components
- use short syntax `<>` to replace `<React.Fragment>`