### PR TITLE
Add validation info to onSubmit

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -17,6 +17,7 @@ import {type Direction} from "./tree";
 import {
   type FormState,
   isValid,
+  isExternallyValid,
   getExtras,
   flatRootErrors,
   freshFormState,
@@ -47,6 +48,7 @@ export type ValidationOps<T> = {
 type FieldId = number;
 type ValidationMap = Map<EncodedPath, Map<FieldId, Validation<mixed>>>;
 type ExternalErrors = null | {+[path: string]: $ReadOnlyArray<string>};
+type SubmitTips = {valid: {client: boolean, external: boolean}};
 
 const noOps = {
   unregister() {},
@@ -324,7 +326,7 @@ type Props<T, ExtraSubmitData> = {|
   // This is *only* used to intialize the form. Further changes will be ignored
   +initialValue: T,
   +feedbackStrategy: FeedbackStrategy,
-  +onSubmit: (T, ExtraSubmitData) => void,
+  +onSubmit: (T, ExtraSubmitData, SubmitTips) => void,
   +onChange: T => void,
   +onValidation: boolean => void,
   +externalErrors: ExternalErrors,
@@ -420,7 +422,16 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
     extraData: ExtraSubmitData
   ) => {
     this.setState({submitted: true});
-    this.props.onSubmit(this.state.formState[0], extraData);
+
+    const {formState} = this.state;
+    const tips: SubmitTips = {
+      valid: {
+        client: isValid(formState),
+        external: isExternallyValid(formState),
+      },
+    };
+
+    this.props.onSubmit(this.state.formState[0], extraData, tips);
   };
 
   _handleChange: (newValue: FormState<T>) => void = (

--- a/src/formState.js
+++ b/src/formState.js
@@ -119,3 +119,12 @@ export function isValid<T>(formState: FormState<T>): boolean {
     formState[1]
   );
 }
+
+export function isExternallyValid<T>(formState: FormState<T>): boolean {
+  return foldMapShapedTree(
+    ({errors: {external}}) => external === "unchecked" || external.length === 0,
+    true,
+    (l, r) => l && r,
+    formState[1]
+  );
+}

--- a/src/test/Form.test.js
+++ b/src/test/Form.test.js
@@ -883,7 +883,12 @@ describe("Form", () => {
     linkOnSubmit();
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit).toHaveBeenLastCalledWith(1, undefined);
+    expect(onSubmit).toHaveBeenLastCalledWith(1, undefined, {
+      valid: {
+        client: true,
+        external: true,
+      },
+    });
   });
 
   it("Calls onSubmit with extra info when submitted", () => {
@@ -901,7 +906,49 @@ describe("Form", () => {
     linkOnSubmit("extra");
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit).toHaveBeenLastCalledWith(expect.anything(), "extra");
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      expect.anything(),
+      "extra",
+      expect.anything()
+    );
+  });
+
+  it("Calls onSubmit with validation info when submitted", () => {
+    const onSubmit = jest.fn();
+    const renderFn = jest.fn(link => (
+      <TestField
+        link={link}
+        validation={s => {
+          if (s.length > 0) {
+            return [];
+          } else {
+            return ["No blank strings"];
+          }
+        }}
+      />
+    ));
+    TestRenderer.create(
+      <Form
+        initialValue={""}
+        onSubmit={onSubmit}
+        externalErrors={{"/": ["External error", "Another external error"]}}
+      >
+        {renderFn}
+      </Form>
+    );
+
+    expect(onSubmit).toHaveBeenCalledTimes(0);
+
+    const linkOnSubmit = renderFn.mock.calls[0][1];
+    linkOnSubmit();
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenLastCalledWith("", undefined, {
+      valid: {
+        client: false,
+        external: false,
+      },
+    });
   });
 
   it("Enforces types on onSubmit", () => {


### PR DESCRIPTION
Add a third parameter `tips` to `onSubmit`
```javascript
type SubmitTips = {valid: {client: boolean, external: boolean}};

onSubmit: (T, ExtraSubmitData, SubmitTips) => void
