### PR TITLE
theseus: add blurred feedback strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Some base strategies are exported as fields on the `FeedbackStrategies` object. 
 | ---------------------------------------------- | ------------------------------------------------------------------------------------ |
 | `FeedbackStrategies.Always`                    | Always show errors (default)                                                         |
 | `FeedbackStrategies.Touched`                   | Show errors for fields which have been touched (changed or blurred)                  |
+| `FeedbackStrategies.Blurred`                   | Show errors for fields which have been blurred                                       |
 | `FeedbackStrategies.Changed`                   | Show errors for fields which have been changed                                       |
 | `FeedbackStrategies.ClientValidationSucceeded` | Show errors for fields which have had their validations pass at any time in the past |
 | `FeedbackStrategies.Pristine`                  | Show errors when the form has not been modified                                      |

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ declare namespace FeedbackStrategies {
   export function not(x: FeedbackStrategy): FeedbackStrategy;
   export const Always: FeedbackStrategy;
   export const Touched: FeedbackStrategy;
+  export const Blurred: FeedbackStrategy;
   export const Changed: FeedbackStrategy;
   export const ClientValidationSucceeded: FeedbackStrategy;
   export const Pristine: FeedbackStrategy;

--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -36,7 +36,7 @@ import {
 import {
   type FormState,
   replaceArrayChild,
-  setExtrasTouched,
+  setExtrasBlurred,
   arrayChild,
   getExtras,
   flatRootErrors,
@@ -157,7 +157,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     const [_, tree] = this.props.link.formState;
     this.props.link.onBlur(
       mapRoot(
-        setExtrasTouched,
+        setExtrasBlurred,
         dangerouslyReplaceArrayChild(index, childTree, tree)
       )
     );

--- a/src/Field.js
+++ b/src/Field.js
@@ -9,7 +9,7 @@ import {
   type ValidationOps,
   validationFnNoOps,
 } from "./Form";
-import {setExtrasTouched, getExtras, isValid} from "./formState";
+import {setExtrasBlurred, getExtras, isValid} from "./formState";
 import alwaysValid from "./alwaysValid";
 
 type Props<T> = {|
@@ -78,7 +78,7 @@ export default class Field<T> extends React.Component<Props<T>> {
 
     this.props.link.onBlur(
       // TODO(zach): Not sure if we should blow away external errors here
-      mapRoot(setExtrasTouched, tree)
+      mapRoot(setExtrasBlurred, tree)
     );
   };
 

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -18,7 +18,7 @@ import {
 import {
   type FormState,
   replaceObjectChild,
-  setExtrasTouched,
+  setExtrasBlurred,
   objectChild,
   getExtras,
   flatRootErrors,
@@ -140,7 +140,7 @@ export default class ObjectField<T: {}> extends React.Component<
     const [_, tree] = this.props.link.formState;
     this.props.link.onBlur(
       mapRoot(
-        setExtrasTouched,
+        setExtrasBlurred,
         dangerouslyReplaceObjectChild(key, childTree, tree)
       )
     );

--- a/src/feedbackStrategies.js
+++ b/src/feedbackStrategies.js
@@ -10,6 +10,9 @@ const strategies = {
   Touched(metaForm: MetaForm, metaField: MetaField) {
     return metaField.touched;
   },
+  Blurred(metaForm: MetaForm, metaField: MetaField) {
+    return metaField.blurred;
+  },
   Changed(metaForm: MetaForm, metaField: MetaField) {
     return metaField.changed;
   },

--- a/src/formState.js
+++ b/src/formState.js
@@ -80,6 +80,10 @@ export function setExtrasTouched({errors, meta}: Extras): Extras {
   return {errors, meta: {...meta, touched: true}};
 }
 
+export function setExtrasBlurred({errors, meta}: Extras): Extras {
+  return {errors, meta: {...meta, touched: true, blurred: true}};
+}
+
 export function replaceObjectChild<T: {}, V>(
   key: string,
   child: FormState<V>,

--- a/src/formState.js
+++ b/src/formState.js
@@ -38,6 +38,7 @@ export function changedFormState<T>(value: T): FormState<T> {
     treeFromValue(value, {
       errors: cleanErrors,
       meta: {
+        blurred: true,
         touched: true,
         changed: true,
         succeeded: false,

--- a/src/formState.js
+++ b/src/formState.js
@@ -76,10 +76,6 @@ export function arrayChild<E>(
   return [value[index], shapedArrayChild(index, tree)];
 }
 
-export function setExtrasTouched({errors, meta}: Extras): Extras {
-  return {errors, meta: {...meta, touched: true}};
-}
-
 export function setExtrasBlurred({errors, meta}: Extras): Extras {
   return {errors, meta: {...meta, touched: true, blurred: true}};
 }

--- a/src/test/Field.test.js
+++ b/src/test/Field.test.js
@@ -121,6 +121,7 @@ describe("Field", () => {
     const tree = linkOnBlur.mock.calls[0][0];
     expect(tree.data).toMatchObject({
       meta: {
+        blurred: true,
         touched: true,
         changed: false,
         succeeded: false,

--- a/src/test/Form.test.js
+++ b/src/test/Form.test.js
@@ -346,6 +346,7 @@ describe("Form", () => {
       expect(forgetShape(tree).data).toEqual({
         meta: {
           touched: false,
+          blurred: false,
           changed: false,
           succeeded: false,
           asyncValidationInFlight: false,

--- a/src/test/feedbackStrategies.test.js
+++ b/src/test/feedbackStrategies.test.js
@@ -26,6 +26,17 @@ describe("feedbackStrategies", () => {
       });
     });
 
+    describe("Blurred", () => {
+      it("returns true when the field is touched", () => {
+        // $FlowFixMe
+        expect(FeedbackStrategies.Blurred(null, {blurred: true})).toBe(true);
+      });
+      it("returns false when the field is not touched", () => {
+        // $FlowFixMe
+        expect(FeedbackStrategies.Blurred(null, {blurred: false})).toBe(false);
+      });
+    });
+
     describe("Changed", () => {
       it("returns true when the field is changed", () => {
         // $FlowFixMe

--- a/src/types.js
+++ b/src/types.js
@@ -13,7 +13,7 @@ export type Err = {
 
 export type MetaField = {
   touched: boolean, // a blur or a change
-  blurred: boolen,
+  blurred: boolean,
   changed: boolean,
   succeeded: boolean,
   asyncValidationInFlight: boolean,

--- a/src/types.js
+++ b/src/types.js
@@ -13,6 +13,7 @@ export type Err = {
 
 export type MetaField = {
   touched: boolean, // a blur or a change
+  blurred: boolen,
   changed: boolean,
   succeeded: boolean,
   asyncValidationInFlight: boolean,
@@ -25,6 +26,7 @@ export type MetaForm = {
 
 export const cleanMeta: MetaField = {
   touched: false,
+  blurred: false,
   changed: false,
   succeeded: false,
   asyncValidationInFlight: false,


### PR DESCRIPTION
## Description
Per issue https://github.com/flexport/formula-one/issues/106 , we want to create a Feedback strategy for fields that have been blurred.

Touched doesn't quite do it, because it's effectively Touched && Blurred, and it's hard to subtract out the Touched part using the primitives since we don't track blurred.

## Test plan
- [x] It passes tests.
- [x] try it on a local project
