### PR TITLE
Fix a bug with element reuse

### DIFF
--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -42,7 +42,7 @@ import {
   flatRootErrors,
   isValid,
 } from "./formState";
-import type {Path} from "./tree";
+import {pathEqual, type Path} from "./tree";
 import alwaysValid from "./alwaysValid";
 
 type ToFieldLink = <T>(T) => FieldLink<T>;
@@ -108,8 +108,17 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     );
   }
 
-  componentDidUpdate() {
-    this.validationFnOps.replace(this.props.validation);
+  componentDidUpdate(prevProps: Props<E>) {
+    if (!pathEqual(prevProps.link.path, this.props.link.path)) {
+      this.validationFnOps.unregister();
+      this.validationFnOps = this.context.registerValidation(
+        this.props.link.path,
+        this.props.validation
+      );
+    } else {
+      // This is a noop if the function hasn't changed
+      this.validationFnOps.replace(this.props.validation);
+    }
   }
 
   componentWillUnmount() {

--- a/src/Field.js
+++ b/src/Field.js
@@ -11,6 +11,7 @@ import {
 } from "./Form";
 import {setExtrasBlurred, getExtras, isValid} from "./formState";
 import alwaysValid from "./alwaysValid";
+import {pathEqual} from "./tree";
 
 type Props<T> = {|
   +link: FieldLink<T>,
@@ -51,8 +52,17 @@ export default class Field<T> extends React.Component<Props<T>> {
     );
   }
 
-  componentDidUpdate() {
-    this.validationFnOps.replace(this.props.validation);
+  componentDidUpdate(prevProps: Props<T>) {
+    if (!pathEqual(prevProps.link.path, this.props.link.path)) {
+      this.validationFnOps.unregister();
+      this.validationFnOps = this.context.registerValidation(
+        this.props.link.path,
+        this.props.validation
+      );
+    } else {
+      // This is a noop if the function hasn't changed
+      this.validationFnOps.replace(this.props.validation);
+    }
   }
 
   componentWillUnmount() {

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -29,7 +29,7 @@ import {
   mapRoot,
   dangerouslyReplaceObjectChild,
 } from "./shapedTree";
-import type {Path} from "./tree";
+import {pathEqual, type Path} from "./tree";
 import alwaysValid from "./alwaysValid";
 
 type ToFieldLink = <T>(T) => FieldLink<T>;
@@ -91,8 +91,17 @@ export default class ObjectField<T: {}> extends React.Component<
     );
   }
 
-  componentDidUpdate() {
-    this.validationFnOps.replace(this.props.validation);
+  componentDidUpdate(prevProps: Props<T>) {
+    if (!pathEqual(prevProps.link.path, this.props.link.path)) {
+      this.validationFnOps.unregister();
+      this.validationFnOps = this.context.registerValidation(
+        this.props.link.path,
+        this.props.validation
+      );
+    } else {
+      // This is a noop if the function hasn't changed
+      this.validationFnOps.replace(this.props.validation);
+    }
   }
 
   componentWillUnmount() {

--- a/src/test/Form.test.js
+++ b/src/test/Form.test.js
@@ -332,7 +332,94 @@ describe("Form", () => {
           b: "beta",
         },
         a: ["zach", "desmond"],
-        f: "theseus", // marker field
+        f: "theseus", // tag field
+      };
+
+      const renderer = TestRenderer.create(
+        <Form initialValue={initialValue}>
+          {link => (
+            <ObjectField link={link}>
+              {(links, {value}) => (
+                <>
+                  <ObjectField link={links.o}>
+                    {links =>
+                      value.f === "theseus" ? (
+                        <TestField
+                          link={links.a}
+                          validation={objectValidation0}
+                          key="reuse"
+                        />
+                      ) : (
+                        <TestField
+                          link={links.b}
+                          validation={objectValidation1}
+                          key="reuse"
+                        />
+                      )
+                    }
+                  </ObjectField>
+                  <ArrayField link={links.a}>
+                    {links =>
+                      value.f === "theseus" ? (
+                        <TestField
+                          link={links[0]}
+                          validation={arrayValidation0}
+                          key="reuse"
+                        />
+                      ) : (
+                        <TestField
+                          link={links[1]}
+                          validation={arrayValidation1}
+                          key="reuse"
+                        />
+                      )
+                    }
+                  </ArrayField>
+                  <TestField link={links.f} />
+                </>
+              )}
+            </ObjectField>
+          )}
+        </Form>
+      );
+
+      expect(objectValidation0).toHaveBeenCalledTimes(1);
+      expect(objectValidation0).toHaveBeenCalledWith("alpha");
+      expect(arrayValidation0).toHaveBeenCalledTimes(1);
+      expect(arrayValidation0).toHaveBeenCalledWith("zach");
+      expect(objectValidation1).toHaveBeenCalledTimes(0);
+      expect(arrayValidation1).toHaveBeenCalledTimes(0);
+
+      objectValidation0.mockClear();
+      arrayValidation0.mockClear();
+
+      // Change the tag field
+      renderer.root.findAllByType(TestInput)[2].instance.change("foo");
+
+      // TODO(zgotsch): If we instead change the first TestField, this first
+      //   validation gets called once on the way up. We would prefer that this
+      //   doesn't happen.
+      expect(objectValidation0).toHaveBeenCalledTimes(0);
+      expect(arrayValidation0).toHaveBeenCalledTimes(0);
+      expect(objectValidation1).toHaveBeenCalledTimes(1);
+      expect(objectValidation1).toHaveBeenCalledWith("beta");
+      expect(arrayValidation1).toHaveBeenCalledTimes(1);
+      expect(arrayValidation1).toHaveBeenCalledWith("desmond");
+    });
+
+    it("doesn't break when elements are reused with customChange", () => {
+      const objectValidation0 = jest.fn(() => []);
+      const objectValidation1 = jest.fn(() => []);
+      const arrayValidation0 = jest.fn(() => []);
+      const arrayValidation1 = jest.fn(() => []);
+
+      const initialValue = {
+        o: {
+          a: "alpha",
+          b: "beta",
+        },
+        a: ["zach", "desmond"],
+        f: "theseus", // tag field
       };
       const otherValue = {
         o: {
@@ -401,6 +488,7 @@ describe("Form", () => {
       objectValidation0.mockClear();
       arrayValidation0.mockClear();
 
+      // Change the tag field
       renderer.root.findAllByType(TestInput)[2].instance.change("foo");
 
       // TODO(zgotsch): If we instead change the first TestField, this first

--- a/src/tree.js
+++ b/src/tree.js
@@ -1,6 +1,7 @@
 // @flow strict
 import {setEq} from "./utils/set";
 import invariant from "./utils/invariant";
+import {zip} from "./utils/array";
 
 export type Tree<T> =
   | {
@@ -34,6 +35,21 @@ export type Direction =
   | {type: "object", key: string}
   | {type: "array", index: number};
 export type Path = Array<Direction>;
+
+function directionEqual(a: Direction, b: Direction): boolean {
+  if (a.type === "object" && b.type === "object") {
+    return a.key === b.key;
+  }
+  if (a.type === "array" && b.type === "array") {
+    return a.index === b.index;
+  }
+  return false;
+}
+export function pathEqual(a: Path, b: Path): boolean {
+  return zip(a, b).every(([l, r]: [Direction, Direction]) =>
+    directionEqual(l, r)
+  );
+}
 
 export function pathFromPathString(pathString: string): Path {
   if (pathString[0] !== "/") {


### PR DESCRIPTION
Previously, when `...Field` elements were reused by React with a different `link` prop, there was a bug where the validation function could be replaced at the wrong path. This occurred whenever the `path` field of the `link` prop changed. The fix is to ensure that when the `path` of the `link` prop changes, we reregister the new validation to the new path. Some additional work had to be done to add an equality function on tree paths, since they should act like value objects.

This bug was introduced in `v0.9.0` with the new way validations are handled in `Form`. There will be an immediate release when this is landed.