### PR TITLE
Upgrade Flow and other dependencies

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,8 +7,6 @@
 [lints]
 
 [options]
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
-suppress_comment=\\(.\\|\n\\)*\\$ExpectError
 include_warnings=true
 esproposal.export_star_as=enable
 

--- a/flow-typed/npm/jest_v24.x.x.js
+++ b/flow-typed/npm/jest_v24.x.x.js
@@ -1,3 +1,6 @@
+// flow-typed signature: 4ad3657d6bb358a2eac5a1e677539a1e
+// flow-typed version: 76f8523085/jest_v24.x.x/flow_>=v0.134.x
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
  (...args: TArguments): TReturn,
  /**
@@ -530,13 +533,36 @@ type JestExtendedMatchersType = {
  ...
 };
 
+// Diffing snapshot utility for Jest (snapshot-diff)
+// https://github.com/jest-community/snapshot-diff
+type SnapshotDiffType = {
+  /**
+   * Compare the difference between the actual in the `expect()`
+   * vs the object inside `valueB` with some extra options.
+   */
+  toMatchDiffSnapshot(
+    valueB: any,
+    options?: {|
+      expand?: boolean;
+      colors?: boolean;
+      contextLines?: number;
+      stablePatchmarks?: boolean;
+      aAnnotation?: string;
+      bAnnotation?: string;
+    |},
+    testName?: string
+  ): void,
+  ...
+}
+
 interface JestExpectType {
   not: JestExpectType &
     EnzymeMatchersType &
     DomTestingLibraryType &
     JestJQueryMatchersType &
     JestStyledComponentsMatchersType &
-    JestExtendedMatchersType;
+    JestExtendedMatchersType &
+    SnapshotDiffType;
   /**
    * If you have a mock function, you can use .lastCalledWith to test what
    * arguments it was last called with.
@@ -807,7 +833,7 @@ type JestObjectType = {
   * Returns the actual module instead of a mock, bypassing all checks on
   * whether the module should receive a mock implementation or not.
   */
- requireActual(moduleName: string): any,
+ requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
  /**
   * Returns a mock module instead of the actual module, bypassing all checks
   * on whether the module should be required normally or not.
@@ -898,7 +924,7 @@ type JestObjectType = {
 type JestSpyType = { calls: JestCallsType, ... };
 
 type JestDoneFn = {|
- (): void,
+ (error?: Error): void,
  fail: (error: Error) => void,
 |};
 
@@ -1127,7 +1153,8 @@ declare var expect: {
    DomTestingLibraryType &
    JestJQueryMatchersType &
    JestStyledComponentsMatchersType &
-   JestExtendedMatchersType,
+   JestExtendedMatchersType &
+   SnapshotDiffType,
  /** Add additional Jasmine matchers to Jest's roster */
  extend(matchers: { [name: string]: JestMatcher, ... }): void,
  /** Add a module that formats application-specific data structures. */

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": "^16.9.0 || ^17.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
@@ -52,11 +52,11 @@
     "eslint-plugin-import": "2.x",
     "eslint-plugin-jsx-a11y": "6.x",
     "eslint-plugin-react": "7.x",
-    "flow-bin": "^0.106.3",
+    "flow-bin": "0.139.0",
     "flow-typed": "^2.6.1",
     "jest": "^24.5.0",
     "prettier": "^1.18.2",
-    "react": "^16.9.0",
-    "react-test-renderer": "^16.9.0"
+    "react": "^17.0.1",
+    "react-test-renderer": "^17.0.1"
   }
 }

--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -93,7 +93,7 @@ function makeLinks<E>(
 }
 
 export default class ArrayField<E> extends React.Component<Props<E>, void> {
-  static defaultProps: {|validation: <T>(_x: T) => Array<$FlowFixMe>|} = {
+  static defaultProps: {|validation: <T>(_x: T) => Array<string>|} = {
     validation: alwaysValid,
   };
   static contextType: React.Context<FormContextPayload<mixed>> = FormContext;

--- a/src/ArrayField.js
+++ b/src/ArrayField.js
@@ -93,10 +93,10 @@ function makeLinks<E>(
 }
 
 export default class ArrayField<E> extends React.Component<Props<E>, void> {
-  static defaultProps = {
+  static defaultProps: {|validation: <T>(_x: T) => Array<$FlowFixMe>|} = {
     validation: alwaysValid,
   };
-  static contextType = FormContext;
+  static contextType: React.Context<FormContextPayload<mixed>> = FormContext;
   context: FormContextPayload<Array<E>>;
 
   validationFnOps: ValidationOps<Array<E>> = validationFnNoOps();
@@ -308,7 +308,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     }
   };
 
-  _removeChildField = (index: number) => {
+  _removeChildField: (index: number) => void = (index: number) => {
     const [oldValue, oldTree] = this.props.link.formState;
 
     const newValue = removeAt(index, oldValue);
@@ -326,7 +326,10 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     }
   };
 
-  _moveChildField = (from: number, to: number) => {
+  _moveChildField: (from: number, to: number) => void = (
+    from: number,
+    to: number
+  ) => {
     const [oldValue, oldTree] = this.props.link.formState;
 
     const newValue = moveFromTo(from, to, oldValue);
@@ -359,7 +362,7 @@ export default class ArrayField<E> extends React.Component<Props<E>, void> {
     this._validateThenApplyCustomChange([customValue, newTree]);
   }
 
-  render() {
+  render(): React.Node {
     const {formState, path} = this.props.link;
     const {shouldShowError} = this.context;
 

--- a/src/EncodedPath.js
+++ b/src/EncodedPath.js
@@ -12,7 +12,7 @@ import {type Path} from "./tree";
 opaque type EncodedPath = string;
 export type {EncodedPath};
 
-export function startsWith(path: EncodedPath, prefix: EncodedPath) {
+export function startsWith(path: EncodedPath, prefix: EncodedPath): boolean {
   return path.startsWith(prefix);
 }
 

--- a/src/ErrorsHelper.js
+++ b/src/ErrorsHelper.js
@@ -25,7 +25,7 @@ type Props<T> = {|
     flattened: Array<string>,
   }) => React.Node,
 |};
-export default function ErrorsHelper<T>(props: Props<T>) {
+export default function ErrorsHelper<T>(props: Props<T>): React.Node {
   const {errors, meta} = getExtras(props.link.formState);
   const flattened = flattenErrors(errors);
   const formContext = React.useContext(FormContext);

--- a/src/Field.js
+++ b/src/Field.js
@@ -37,10 +37,10 @@ function getErrors(errors: Err) {
 }
 
 export default class Field<T> extends React.Component<Props<T>> {
-  static defaultProps = {
+  static defaultProps: {|validation: <T>(_x: T) => $FlowFixMe|} = {
     validation: alwaysValid,
   };
-  static contextType = FormContext;
+  static contextType: React.Context<FormContextPayload<mixed>> = FormContext;
   context: FormContextPayload<T>;
 
   validationFnOps: ValidationOps<T> = validationFnNoOps();
@@ -83,7 +83,7 @@ export default class Field<T> extends React.Component<Props<T>> {
     onChange(newFormState);
   };
 
-  onBlur = () => {
+  onBlur: (() => void) = () => {
     const [_, tree] = this.props.link.formState;
 
     this.props.link.onBlur(
@@ -92,7 +92,7 @@ export default class Field<T> extends React.Component<Props<T>> {
     );
   };
 
-  render() {
+  render(): React.Node {
     const {formState} = this.props.link;
     const [value] = formState;
     const {meta, errors} = getExtras(formState);

--- a/src/Field.js
+++ b/src/Field.js
@@ -37,7 +37,7 @@ function getErrors(errors: Err) {
 }
 
 export default class Field<T> extends React.Component<Props<T>> {
-  static defaultProps: {|validation: <T>(_x: T) => $FlowFixMe|} = {
+  static defaultProps: {|validation: <T>(_x: T) => Array<string>|} = {
     validation: alwaysValid,
   };
   static contextType: React.Context<FormContextPayload<mixed>> = FormContext;
@@ -83,7 +83,7 @@ export default class Field<T> extends React.Component<Props<T>> {
     onChange(newFormState);
   };
 
-  onBlur: (() => void) = () => {
+  onBlur: () => void = () => {
     const [_, tree] = this.props.link.formState;
 
     this.props.link.onBlur(

--- a/src/Form.js
+++ b/src/Form.js
@@ -349,7 +349,7 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
 > {
   static defaultProps: {|
     externalErrors: null,
-    feedbackStrategy: () => $FlowFixMe,
+    feedbackStrategy: () => boolean,
     onChange: () => void,
     onSubmit: () => void,
     onValidation: () => void,

--- a/src/Form.js
+++ b/src/Form.js
@@ -50,7 +50,8 @@ type ValidationMap = Map<EncodedPath, Map<FieldId, Validation<mixed>>>;
 type ExternalErrors = null | {+[path: string]: $ReadOnlyArray<string>};
 type SubmitTips = {valid: {client: boolean, external: boolean}};
 
-const noOps = {
+// flowlint-next-line unclear-type:off
+const noOps: {unregister: () => void, replace: any => void} = {
   unregister() {},
   replace() {},
 };
@@ -346,7 +347,13 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
   Props<T, ExtraSubmitData>,
   State<T>
 > {
-  static defaultProps = {
+  static defaultProps: {|
+    externalErrors: null,
+    feedbackStrategy: () => $FlowFixMe,
+    onChange: () => void,
+    onSubmit: () => void,
+    onValidation: () => void,
+  |} = {
     onChange: () => {},
     onSubmit: () => {},
     onValidation: () => {},
@@ -357,7 +364,7 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
   static getDerivedStateFromProps(
     props: Props<T, ExtraSubmitData>,
     state: State<T>
-  ) {
+  ): null | {|formState: FormState<T>, oldExternalErrors: ExternalErrors|} {
     if (props.externalErrors !== state.oldExternalErrors) {
       const newTree = applyExternalErrorsToFormState<T>(
         props.externalErrors,
@@ -372,7 +379,7 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
   }
 
   validations: ValidationMap;
-  initialValidationComplete = false;
+  initialValidationComplete: boolean = false;
   pendingValidationPath: null | Path = null;
 
   constructor(props: Props<T, ExtraSubmitData>) {
@@ -469,7 +476,7 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
    * Keeps validation errors from becoming stale when validation functions of
    * children change.
    */
-  recomputeErrorsAtPathAndRender = (path: Path) => {
+  recomputeErrorsAtPathAndRender: (path: Path) => void = (path: Path) => {
     this.setState(({formState: [rootValue, tree]}) => {
       const value = getValueAtPath(path, rootValue);
       const errors = validateAtPath(path, value, this.validations);
@@ -488,7 +495,10 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
     });
   };
 
-  handleRegisterValidation = <NodeT>(
+  handleRegisterValidation: <NodeT>(
+    path: Path,
+    fn: (NodeT) => Array<string>
+  ) => ValidationOps<NodeT> = <NodeT>(
     path: Path,
     fn: NodeT => Array<string>
   ): ValidationOps<NodeT> => {
@@ -519,7 +529,11 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
     };
   };
 
-  replaceValidation = <NodeT>(
+  replaceValidation: <NodeT>(
+    path: Path,
+    fieldId: FieldId,
+    fn: (NodeT) => Array<string>
+  ) => void = <NodeT>(
     path: Path,
     fieldId: FieldId,
     fn: NodeT => Array<string>
@@ -563,7 +577,10 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
     this.recomputeErrorsAtPathAndRender(path);
   };
 
-  unregisterValidation = (path: Path, fieldId: FieldId) => {
+  unregisterValidation: (path: Path, fieldId: FieldId) => void = (
+    path: Path,
+    fieldId: FieldId
+  ) => {
     const encodedPath = encodePath(path);
     const map = this.validations.get(encodedPath);
     invariant(map != null, "Couldn't find handler map during unregister");
@@ -580,7 +597,7 @@ export default class Form<T, ExtraSubmitData> extends React.Component<
     this.recomputeErrorsAtPathAndRender(path);
   };
 
-  render() {
+  render(): React.Node {
     const {formState} = this.state;
     const metaForm = {
       pristine: this.state.pristine,

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -75,10 +75,10 @@ export default class ObjectField<T: {}> extends React.Component<
   Props<T>,
   void
 > {
-  static contextType = FormContext;
+  static contextType: React.Context<FormContextPayload<mixed>> = FormContext;
   context: FormContextPayload<T>;
-  static _contextType = FormContext;
-  static defaultProps = {
+  static _contextType: React.Context<FormContextPayload<mixed>> = FormContext;
+  static defaultProps: {|validation: <T>(_x: T) => $FlowFixMe|} = {
     validation: alwaysValid,
   };
 
@@ -155,7 +155,7 @@ export default class ObjectField<T: {}> extends React.Component<
     );
   };
 
-  render() {
+  render(): React.Node {
     const {formState} = this.props.link;
     const {shouldShowError} = this.context;
 

--- a/src/ObjectField.js
+++ b/src/ObjectField.js
@@ -78,7 +78,7 @@ export default class ObjectField<T: {}> extends React.Component<
   static contextType: React.Context<FormContextPayload<mixed>> = FormContext;
   context: FormContextPayload<T>;
   static _contextType: React.Context<FormContextPayload<mixed>> = FormContext;
-  static defaultProps: {|validation: <T>(_x: T) => $FlowFixMe|} = {
+  static defaultProps: {|validation: <T>(_x: T) => Array<string>|} = {
     validation: alwaysValid,
   };
 

--- a/src/alwaysValid.js
+++ b/src/alwaysValid.js
@@ -1,5 +1,5 @@
 // @flow strict
 
-export default function alwaysValid<T>(_x: T) {
+export default function alwaysValid<T>(_x: T): Array<$FlowFixMe> {
   return [];
 }

--- a/src/alwaysValid.js
+++ b/src/alwaysValid.js
@@ -1,5 +1,5 @@
 // @flow strict
 
-export default function alwaysValid<T>(_x: T): Array<$FlowFixMe> {
+export default function alwaysValid<T>(_x: T): Array<string> {
   return [];
 }

--- a/src/feedbackStrategies.js
+++ b/src/feedbackStrategies.js
@@ -4,25 +4,25 @@ import type {MetaForm, MetaField} from "./types";
 export type FeedbackStrategy = (MetaForm, MetaField) => boolean;
 
 const strategies = {
-  Always() {
+  Always(): boolean {
     return true;
   },
-  Touched(metaForm: MetaForm, metaField: MetaField) {
+  Touched(metaForm: MetaForm, metaField: MetaField): boolean {
     return metaField.touched;
   },
-  Blurred(metaForm: MetaForm, metaField: MetaField) {
+  Blurred(metaForm: MetaForm, metaField: MetaField): boolean {
     return metaField.blurred;
   },
-  Changed(metaForm: MetaForm, metaField: MetaField) {
+  Changed(metaForm: MetaForm, metaField: MetaField): boolean {
     return metaField.changed;
   },
-  ClientValidationSucceeded(metaForm: MetaForm, metaField: MetaField) {
+  ClientValidationSucceeded(metaForm: MetaForm, metaField: MetaField): boolean {
     return metaField.succeeded;
   },
-  Pristine(metaForm: MetaForm) {
+  Pristine(metaForm: MetaForm): boolean {
     return metaForm.pristine;
   },
-  Submitted(metaForm: MetaForm) {
+  Submitted(metaForm: MetaForm): boolean {
     return metaForm.submitted;
   },
 };

--- a/src/shapedTree.js
+++ b/src/shapedTree.js
@@ -58,7 +58,7 @@ export function shapePath<T>(data: T, path: Path): null | ShapedPath<T> {
     firstPart.type === "object" &&
     Object.hasOwnProperty.call(data, firstPart.key)
   ) {
-    // $FlowFixMe: This is safe
+    // $FlowFixMe[incompatible-use]: This is safe
     const restPath = shapePath(data[firstPart.key], restParts);
     if (restPath === null) {
       return null;
@@ -172,7 +172,7 @@ export function updateAtPath<T, Node>(
       updater,
       tree.children[firstStep.index]
     );
-    // $FlowFixMe(zach): I think this is safe, might need GADTs for the type checker to understand why
+    // $FlowFixMe[incompatible-return](zach): I think this is safe, might need GADTs for the type checker to understand why
     return dangerouslyReplaceArrayChild(firstStep.index, newChild, tree);
   }
   if (tree.type === "object") {
@@ -186,7 +186,7 @@ export function updateAtPath<T, Node>(
       `Tried to take path key ${firstStep.key} but it isn't present on object in tree`
     );
     const newChild = updateAtPath(restStep, updater, nextTree);
-    // $FlowFixMe(zach): I think this is safe, might need GADTs for the type checker to understand why
+    // $FlowFixMe[incompatible-return](zach): I think this is safe, might need GADTs for the type checker to understand why
     return dangerouslyReplaceObjectChild(firstStep.key, newChild, tree);
   }
   throw new Error("unreachable");

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import TestRenderer from "react-test-renderer";
-import {type JestMockT} from "jest";
 import Form from "../Form";
 import ArrayField from "../ArrayField";
 import {type FieldLink} from "../types";
@@ -17,7 +16,7 @@ describe("ArrayField", () => {
       const formState = mockFormState(["one", "two", "three"]);
       const link = mockLink(formState);
 
-      // $ExpectError
+      // $FlowExpectedError
       <ArrayField link={link} validation={(_e: empty) => []}>
         {() => null}
       </ArrayField>;
@@ -129,7 +128,7 @@ describe("ArrayField", () => {
       const link = mockLink(formState);
 
       <ArrayField link={link}>
-        {/* $ExpectError */}
+        {/* $FlowExpectedError */}
         {(links: empty) => {
           console.log(links);
           return null;
@@ -191,7 +190,7 @@ describe("ArrayField", () => {
       arrayLinks[0].onBlur(newElementTree);
 
       expect(link.onBlur).toHaveBeenCalled();
-      const linkOnBlur: JestMockT = link.onBlur;
+      const linkOnBlur: any = link.onBlur;
       const newArrayTree = linkOnBlur.mock.calls[0][0];
       expect(newArrayTree.data.meta).toMatchObject({
         touched: true,

--- a/src/test/ArrayField.test.js
+++ b/src/test/ArrayField.test.js
@@ -16,7 +16,7 @@ describe("ArrayField", () => {
       const formState = mockFormState(["one", "two", "three"]);
       const link = mockLink(formState);
 
-      // $FlowExpectedError
+      // $FlowExpectedError[incompatible-type]
       <ArrayField link={link} validation={(_e: empty) => []}>
         {() => null}
       </ArrayField>;
@@ -77,7 +77,7 @@ describe("ArrayField", () => {
 
     it("Passes additional information to its render function", () => {
       const formState = mockFormState(["value"]);
-      // $FlowFixMe
+      // $FlowFixMe[incompatible-use]
       formState[1].data.errors = {
         external: ["An external error"],
         client: ["A client error"],
@@ -128,7 +128,7 @@ describe("ArrayField", () => {
       const link = mockLink(formState);
 
       <ArrayField link={link}>
-        {/* $FlowExpectedError */}
+        {/* $FlowExpectedError[incompatible-type] */}
         {(links: empty) => {
           console.log(links);
           return null;

--- a/src/test/Field.test.js
+++ b/src/test/Field.test.js
@@ -15,7 +15,7 @@ describe("Field", () => {
     const formState = mockFormState("Hello world.");
     const link = mockLink(formState);
 
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     <Field link={link} validation={(_e: empty) => []}>
       {() => null}
     </Field>;
@@ -159,7 +159,7 @@ describe("Field", () => {
     const link = mockLink(formState);
 
     <Field link={link}>
-      {/* $FlowExpectedError */}
+      {/* $FlowExpectedError[incompatible-type] */}
       {(_value: empty) => null}
     </Field>;
 
@@ -171,11 +171,11 @@ describe("Field", () => {
     const link: FieldLink<string> = mockLink(formState);
 
     <Field link={link}>
-      {/* $FlowExpectedError */}
+      {/* $FlowExpectedError[incompatible-type] */}
       {(_value, _errors, _onChange: empty) => null}
     </Field>;
 
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type-arg]
     <Field link={link}>
       {(_value, _errors, _onChange: number => void) => null}
     </Field>;
@@ -187,7 +187,7 @@ describe("Field", () => {
 
   it("Passes additional information to its render function", () => {
     const formState = mockFormState(10);
-    // $FlowFixMe
+    // $FlowFixMe[incompatible-use]
     formState[1].data.errors = {
       external: ["An external error"],
       client: ["A client error"],

--- a/src/test/Field.test.js
+++ b/src/test/Field.test.js
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import TestRenderer from "react-test-renderer";
-import {type JestMockT} from "jest";
 
 import Field from "../Field";
 import {type FieldLink} from "../types";
@@ -16,7 +15,7 @@ describe("Field", () => {
     const formState = mockFormState("Hello world.");
     const link = mockLink(formState);
 
-    // $ExpectError
+    // $FlowExpectedError
     <Field link={link} validation={(_e: empty) => []}>
       {() => null}
     </Field>;
@@ -117,7 +116,7 @@ describe("Field", () => {
     inner.instance.blur();
     expect(link.onBlur).toHaveBeenCalledTimes(1);
 
-    const linkOnBlur: JestMockT = link.onBlur;
+    const linkOnBlur: any = link.onBlur;
     const tree = linkOnBlur.mock.calls[0][0];
     expect(tree.data).toMatchObject({
       meta: {
@@ -160,7 +159,7 @@ describe("Field", () => {
     const link = mockLink(formState);
 
     <Field link={link}>
-      {/* $ExpectError */}
+      {/* $FlowExpectedError */}
       {(_value: empty) => null}
     </Field>;
 
@@ -172,11 +171,11 @@ describe("Field", () => {
     const link: FieldLink<string> = mockLink(formState);
 
     <Field link={link}>
-      {/* $ExpectError */}
+      {/* $FlowExpectedError */}
       {(_value, _errors, _onChange: empty) => null}
     </Field>;
 
-    // $ExpectError
+    // $FlowExpectedError
     <Field link={link}>
       {(_value, _errors, _onChange: number => void) => null}
     </Field>;

--- a/src/test/Form.test.js
+++ b/src/test/Form.test.js
@@ -1139,13 +1139,12 @@ describe("Form", () => {
   it("Enforces types on onSubmit", () => {
     const onSubmit: (value: number, extra: "extra") => void = () => {};
     TestRenderer.create(
+      // $FlowExpectedError
       <Form initialValue={1} onSubmit={onSubmit}>
         {(_, onSubmit) => (
           <button
             onClick={() => {
-              // $ExpectError
               onSubmit();
-              // $ExpectError
               onSubmit("hello");
               onSubmit("extra");
             }}

--- a/src/test/Form.test.js
+++ b/src/test/Form.test.js
@@ -1139,7 +1139,7 @@ describe("Form", () => {
   it("Enforces types on onSubmit", () => {
     const onSubmit: (value: number, extra: "extra") => void = () => {};
     TestRenderer.create(
-      // $FlowExpectedError
+      // $FlowExpectedError[incompatible-type]
       <Form initialValue={1} onSubmit={onSubmit}>
         {(_, onSubmit) => (
           <button

--- a/src/test/ObjectField.test.js
+++ b/src/test/ObjectField.test.js
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import TestRenderer from "react-test-renderer";
-import {type JestMockT} from "jest";
 import {FormContext} from "../Form";
 import ObjectField from "../ObjectField";
 import Form from "../Form";
@@ -33,12 +32,12 @@ describe("ObjectField", () => {
       const formState = mockFormState(formStateInner);
       const link: FieldLink<TestObject> = mockLink(formState);
 
-      // $ExpectError
+      // $FlowExpectedError
       <ObjectField link={link} validation={(_e: empty) => []}>
         {() => null}
       </ObjectField>;
 
-      // $ExpectError
+      // $FlowExpectedError
       <ObjectField link={link} validation={(_e: {|string: string|}) => []}>
         {() => null}
       </ObjectField>;
@@ -164,7 +163,7 @@ describe("ObjectField", () => {
       const link: FieldLink<TestObject> = mockLink(formState);
 
       <ObjectField link={link}>
-        {/* $ExpectError */}
+        {/* $FlowExpectedError */}
         {(links: empty) => {
           console.log(links);
           return null;
@@ -172,7 +171,7 @@ describe("ObjectField", () => {
       </ObjectField>;
 
       <ObjectField link={link}>
-        {/* $ExpectError */}
+        {/* $FlowExpectedError */}
         {(links: {|string: FieldLink<string>|}) => {
           console.log(links);
           return null;
@@ -242,7 +241,7 @@ describe("ObjectField", () => {
 
       expect(link.onBlur).toHaveBeenCalled();
 
-      const linkOnBlur: JestMockT = link.onBlur;
+      const linkOnBlur: any = link.onBlur;
       const newObjectTree = linkOnBlur.mock.calls[0][0];
       expect(newObjectTree.children.number).toBe(newChildTree);
       expect(newObjectTree.data.meta).toMatchObject({

--- a/src/test/ObjectField.test.js
+++ b/src/test/ObjectField.test.js
@@ -32,12 +32,12 @@ describe("ObjectField", () => {
       const formState = mockFormState(formStateInner);
       const link: FieldLink<TestObject> = mockLink(formState);
 
-      // $FlowExpectedError
+      // $FlowExpectedError[incompatible-type]
       <ObjectField link={link} validation={(_e: empty) => []}>
         {() => null}
       </ObjectField>;
 
-      // $FlowExpectedError
+      // $FlowExpectedError[prop-missing]
       <ObjectField link={link} validation={(_e: {|string: string|}) => []}>
         {() => null}
       </ObjectField>;
@@ -98,7 +98,7 @@ describe("ObjectField", () => {
 
     it("Passes additional information to its render function", () => {
       const formState = mockFormState({inner: "value"});
-      // $FlowFixMe
+      // $FlowFixMe[incompatible-use]
       formState[1].data.errors = {
         external: ["An external error"],
         client: ["A client error"],
@@ -163,7 +163,7 @@ describe("ObjectField", () => {
       const link: FieldLink<TestObject> = mockLink(formState);
 
       <ObjectField link={link}>
-        {/* $FlowExpectedError */}
+        {/* $FlowExpectedError[incompatible-type] */}
         {(links: empty) => {
           console.log(links);
           return null;
@@ -171,7 +171,7 @@ describe("ObjectField", () => {
       </ObjectField>;
 
       <ObjectField link={link}>
-        {/* $FlowExpectedError */}
+        {/* $FlowExpectedError[prop-missing] */}
         {(links: {|string: FieldLink<string>|}) => {
           console.log(links);
           return null;

--- a/src/test/TestField.js
+++ b/src/test/TestField.js
@@ -18,7 +18,7 @@ export class TestInput extends React.Component<{|
   blur() {
     this.props.onBlur();
   }
-  render() {
+  render(): null {
     return null;
   }
 }
@@ -28,7 +28,7 @@ type Props = {|
   validation?: Validation<string>,
 |};
 
-const TestField = (props: Props) => {
+const TestField = (props: Props): React.Node => {
   const validation = props.validation || alwaysValid;
 
   return (

--- a/src/test/TestForm.js
+++ b/src/test/TestForm.js
@@ -20,7 +20,7 @@ export default function TestForm({
   registerValidation = () => ({replace: () => {}, unregister: () => {}}),
   applyCustomChangeToTree = (path, formState) => formState,
   applyChangeToNode = (path, formState) => formState,
-}: Props = {}) {
+}: Props = {}): React.Node {
   return (
     <FormContext.Provider
       value={{

--- a/src/test/feedbackStrategies.test.js
+++ b/src/test/feedbackStrategies.test.js
@@ -17,33 +17,39 @@ describe("feedbackStrategies", () => {
 
     describe("Touched", () => {
       it("returns true when the field is touched", () => {
-        // $FlowFixMe
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-call]
         expect(FeedbackStrategies.Touched(null, {touched: true})).toBe(true);
       });
       it("returns false when the field is not touched", () => {
-        // $FlowFixMe
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-call]
         expect(FeedbackStrategies.Touched(null, {touched: false})).toBe(false);
       });
     });
 
     describe("Blurred", () => {
       it("returns true when the field is blurred", () => {
-        // $FlowFixMe
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-call]
         expect(FeedbackStrategies.Blurred(null, {blurred: true})).toBe(true);
       });
       it("returns false when the field is not blurred", () => {
-        // $FlowFixMe
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-call]
         expect(FeedbackStrategies.Blurred(null, {blurred: false})).toBe(false);
       });
     });
 
     describe("Changed", () => {
       it("returns true when the field is changed", () => {
-        // $FlowFixMe
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-call]
         expect(FeedbackStrategies.Changed(null, {changed: true})).toBe(true);
       });
       it("returns false when the field is not changed", () => {
-        // $FlowFixMe
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-call]
         expect(FeedbackStrategies.Changed(null, {changed: false})).toBe(false);
       });
     });
@@ -51,13 +57,15 @@ describe("feedbackStrategies", () => {
     describe("ClientValidationSucceeded", () => {
       it("returns true when the field has passed client validations in the past", () => {
         expect(
-          // $FlowFixMe
+          // $FlowFixMe[prop-missing]
+          // $FlowFixMe[incompatible-call]
           FeedbackStrategies.ClientValidationSucceeded(null, {succeeded: true})
         ).toBe(true);
       });
       it("returns false when the field has not passed client validations in the past", () => {
         expect(
-          // $FlowFixMe
+          // $FlowFixMe[prop-missing]
+          // $FlowFixMe[incompatible-call]
           FeedbackStrategies.ClientValidationSucceeded(null, {succeeded: false})
         ).toBe(false);
       });
@@ -65,22 +73,22 @@ describe("feedbackStrategies", () => {
 
     describe("Pristine", () => {
       it("returns true when the form is pristine", () => {
-        // $FlowFixMe
+        // $FlowFixMe[prop-missing]
         expect(FeedbackStrategies.Pristine({pristine: true})).toBe(true);
       });
       it("returns false when the form is not pristine", () => {
-        // $FlowFixMe
+        // $FlowFixMe[prop-missing]
         expect(FeedbackStrategies.Pristine({pristine: false})).toBe(false);
       });
     });
 
     describe("Submitted", () => {
       it("returns true when the form is submitted", () => {
-        // $FlowFixMe
+        // $FlowFixMe[prop-missing]
         expect(FeedbackStrategies.Submitted({submitted: true})).toBe(true);
       });
       it("returns false when the form is not submitted", () => {
-        // $FlowFixMe
+        // $FlowFixMe[prop-missing]
         expect(FeedbackStrategies.Submitted({submitted: false})).toBe(false);
       });
     });
@@ -91,7 +99,7 @@ describe("feedbackStrategies", () => {
     const f: FeedbackStrategy = () => false;
 
     function callStrategy(strategy: FeedbackStrategy) {
-      // $FlowFixMe
+      // $FlowFixMe[incompatible-call]
       return strategy();
     }
 

--- a/src/testutils/LinkTap.js
+++ b/src/testutils/LinkTap.js
@@ -30,7 +30,7 @@ export default class LinkTap<T> extends React.Component<Props<T>> {
     this.props.link.onBlur(newMeta);
   };
 
-  render() {
+  render(): React.Node {
     const {link} = this.props;
     const tappedLink: FieldLink<T> = {
       path: link.path,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2590,10 +2590,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flow-bin@^0.106.3:
-  version "0.106.3"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.106.3.tgz#87b5647bc23ae0efceabb6c50490c02a8478960c"
-  integrity sha512-QDwmhsMmiASmwgr6r2WTz9RPsN0pb84PY0whz0JqFaBX7/Fx2wj2MOtjbR2yv+qWZnozP9U40Jd9LLt8rC3WSQ==
+flow-bin@0.139.0:
+  version "0.139.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.139.0.tgz#3ad6c75460be45b64f00521035c5affb3c440df5"
+  integrity sha512-eilVetLwztYtKjRj//4OsJ7aw47hsUZ8GTINxaZHWhpqiFikErQL0sV/3hQtpm54w9FuS2PO4yvbU0pWrtckqg==
 
 flow-typed@^2.6.1:
   version "2.6.1"
@@ -4718,7 +4718,7 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -4774,7 +4774,12 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-is@^16.8.1, react-is@^16.9.0:
+"react-is@^16.12.0 || ^17.0.0", react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^16.8.1:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
@@ -4784,24 +4789,31 @@ react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.5.tgz#c54ac229dd66b5afe0de5acbe47647c3da692ff8"
   integrity sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==
 
-react-test-renderer@^16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.9.0.tgz#7ed657a374af47af88f66f33a3ef99c9610c8ae9"
-  integrity sha512-R62stB73qZyhrJo7wmCW9jgl/07ai+YzvouvCXIJLBkRlRqLx4j9RqcLEAfNfU3OxTGucqR2Whmn3/Aad6L3hQ==
+react-shallow-renderer@^16.13.1:
+  version "16.14.1"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz#bf0d02df8a519a558fd9b8215442efa5c840e124"
+  integrity sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==
   dependencies:
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    react-is "^16.9.0"
-    scheduler "^0.15.0"
+    react-is "^16.12.0 || ^17.0.0"
 
-react@^16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
-  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
+react-test-renderer@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
+  integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^17.0.2"
+    react-shallow-renderer "^16.13.1"
+    scheduler "^0.20.2"
+
+react@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -5133,10 +5145,10 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
-  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
This fixes an issue that appears in VS Code when `formula-one` is used in a codebase that depends on more recent versions of Flow. Also updates dependencies/peer dependencies to account for React 17!